### PR TITLE
Enclave Base

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -79,12 +79,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"adI" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = 33
-	},
-/turf/closed/indestructible/vaultdoor,
-/area/f13/vault)
 "adK" = (
 /obj/machinery/door/poddoor/ert{
 	id = "lock2"
@@ -104,12 +98,6 @@
 /area/f13/vault)
 "aeH" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
-/turf/open/floor/wood,
-/area/f13/vault)
-"afE" = (
-/obj/machinery/door/airlock/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/rag,
 /turf/open/floor/wood,
 /area/f13/vault)
 "agt" = (
@@ -219,13 +207,6 @@
 /obj/item/reagent_containers/food/snacks/doughslice,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
-"ama" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "anz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -245,12 +226,6 @@
 /obj/item/ammo_box/shotgun/bean,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
-	},
-/area/f13/vault)
-"aob" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
 	},
 /area/f13/vault)
 "apb" = (
@@ -343,22 +318,11 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"avl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/departments/examroom,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "avm" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"awO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
 "awP" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
@@ -494,11 +458,6 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"aBy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/operating,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "aBF" = (
 /obj/structure/table/wood,
@@ -798,10 +757,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker)
-"aTp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/vault)
 "aTC" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -870,13 +825,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"aXC" = (
-/obj/structure/rack,
-/obj/item/storage/belt,
-/obj/item/storage/belt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "aXE" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1312,17 +1260,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"bAE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
-	},
-/obj/structure/decoration/rag,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "bAG" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/item/pda/quartermaster,
@@ -1373,21 +1310,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"bCA" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_y = 31
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "bCL" = (
 /obj/machinery/light{
 	dir = 4;
@@ -1398,10 +1320,6 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/f13/vault)
-"bCR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "bDq" = (
 /obj/machinery/conveyor{
@@ -1457,11 +1375,6 @@
 "bFu" = (
 /turf/open/water,
 /area/f13/underground/cave)
-"bGb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "bHb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1473,12 +1386,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"bHX" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "bIi" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -1599,19 +1506,6 @@
 	network = list("Vault")
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"bRt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"bRu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/flour,
-/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "bRz" = (
 /obj/structure/cable{
@@ -1740,11 +1634,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"bZo" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider,
-/turf/open/floor/wood,
-/area/f13/vault)
 "bZy" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
@@ -1779,12 +1668,6 @@
 /obj/structure/sign/warning,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"cbY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "ccw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1905,11 +1788,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"clD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "clW" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -2022,23 +1900,11 @@
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"cqc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "crs" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"crD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/middle{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
 "csa" = (
 /obj/structure/table/wood,
@@ -2050,10 +1916,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"cuk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "cvc" = (
 /obj/structure/closet/crate,
 /turf/open/floor/f13/wood{
@@ -2105,12 +1967,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"cxg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "cxL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2293,16 +2149,6 @@
 "cIT" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
-"cJK" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "cKh" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2369,22 +2215,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"cOX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
-"cPm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
 "cQF" = (
 /obj/machinery/shower{
 	dir = 4
@@ -2451,13 +2281,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"cUk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	pixel_x = 16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "cUJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2834,16 +2657,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"dsr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "dtD" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2982,31 +2795,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"dDR" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"dEi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/dinnerware,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
-"dEy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/departments/chemistry,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
-"dEU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
 "dFC" = (
 /obj/machinery/light/fo13colored/Red{
@@ -3689,11 +3477,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"eoT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "epr" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves{
@@ -3725,14 +3508,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"eqU" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/turf/open/floor/wood,
 /area/f13/vault)
 "erm" = (
 /obj/machinery/light{
@@ -3770,18 +3545,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ewi" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/vault)
 "ewu" = (
 /obj/structure/table,
 /obj/item/wrench/power,
@@ -4010,42 +3773,12 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"eLG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "eLS" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"eNv" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/wolf/alpha{
-	faction = list("raider")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
-"eNW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs{
-	icon = 'icons/obj/stairs.dmi'
-	},
-/area/f13/vault)
-"eOE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "eOH" = (
 /obj/item/am_shielding_container,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -4150,18 +3883,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"eXH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Business"
-	},
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "eXT" = (
 /obj/machinery/light/fo13colored/Red,
 /turf/open/floor/mineral/plastitanium,
@@ -4208,10 +3929,6 @@
 "eZM" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"fab" = (
-/obj/structure/fans/tiny,
-/turf/closed/indestructible/vaultdoor,
 /area/f13/vault)
 "fac" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -4319,15 +4036,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"feM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
 "feR" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
@@ -4382,14 +4090,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"fiH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor2"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "fiJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -4404,14 +4104,6 @@
 "fjt" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/vault)
-"fjD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/freezer,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
 "fjH" = (
 /obj/machinery/light{
@@ -4546,12 +4238,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"fsI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "ftC" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
@@ -4561,15 +4247,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"ftQ" = (
-/obj/structure/fans/tiny,
-/obj/structure/fireaxecabinet{
-	pixel_x = 33
-	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "fud" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4762,17 +4439,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"fFN" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/vault)
-"fFS" = (
-/obj/machinery/autolathe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/vault)
 "fGz" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/f13/vaultdoctor,
@@ -4809,15 +4475,6 @@
 /obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"fId" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "vaultelevator";
-	name = "Blast Door Exit";
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "fIu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -4896,16 +4553,6 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
-"fMC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "fMG" = (
 /obj/structure/dresser,
 /obj/item/stack/medical/gauze/cyborg,
@@ -4974,13 +4621,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
-"fRh" = (
-/obj/machinery/workbench/advanced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 10
-	},
-/area/f13/vault)
 "fRE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -5020,13 +4660,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"fUD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/wood,
-/area/f13/vault)
 "fUY" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -5044,12 +4677,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"fWx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "fWM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5273,12 +4900,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"gjL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_heater,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "gkf" = (
 /obj/machinery/door/window/brigdoor/security/cell/northleft{
 	dir = 4
@@ -5291,11 +4912,6 @@
 	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/vault)
-"gkP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "glz" = (
 /obj/structure/chair/f13chair2{
@@ -5409,15 +5025,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"gqE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"gqF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "grL" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner{
@@ -5447,16 +5054,6 @@
 /obj/structure/rack,
 /obj/item/storage/box/PDAs,
 /turf/open/floor/carpet/black,
-/area/f13/vault)
-"gsC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "surfacevaultladder";
-	name = "maintenance ladder"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "gsH" = (
 /obj/item/storage/trash_stack,
@@ -5577,24 +5174,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"gyG" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach{
-	faction = list("raider")
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"gyK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/item/reagent_containers/food/condiment/ketchup{
-	pixel_x = -2;
-	pixel_y = 15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "gyN" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -5814,14 +5393,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"gIA" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/wood,
-/area/f13/vault)
 "gJi" = (
 /obj/structure/bookcase/random,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -5975,11 +5546,6 @@
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"gTe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "gTQ" = (
 /obj/structure/chair{
 	dir = 8
@@ -6089,11 +5655,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"gYU" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
 "hae" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v3,
@@ -6206,14 +5767,6 @@
 "heT" = (
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
-"heW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/glass,
-/obj/item/clothing/mask/gas/glass,
-/obj/item/clothing/mask/gas/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "hfI" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/f13{
@@ -6460,12 +6013,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"huH" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "huM" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker{
@@ -6508,11 +6055,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/bunker)
-"hyg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/f13/vault)
 "hys" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
@@ -6682,10 +6224,6 @@
 /obj/structure/bed/old,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"hJL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/vault)
 "hJV" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6761,22 +6299,10 @@
 	dir = 10
 	},
 /area/f13/vault)
-"hQs" = (
-/obj/structure/rack,
-/obj/item/mop/advanced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/broom,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "hQR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
-"hRh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "hRL" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -6900,11 +6426,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"ibl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "ica" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -6941,11 +6462,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
-"idq" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "idu" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -7053,16 +6569,6 @@
 /obj/structure/debris/v4,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"ilm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "surfacevaultelevatorladder";
-	name = "maintenance ladder"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "ilS" = (
 /obj/structure/table,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -7235,11 +6741,6 @@
 /obj/structure/stacklifter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"iyd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "iyf" = (
 /obj/machinery/computer/robotics{
 	dir = 4
@@ -7427,35 +6928,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"iKU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "iMf" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"iMj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
-"iMr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 5
-	},
-/area/f13/vault)
-"iNt" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "iOg" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -7472,12 +6948,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"iOm" = (
-/obj/structure/mirror,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "iOq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -7497,23 +6967,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"iPg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 9;
-	pixel_y = 19
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "iPY" = (
 /obj/machinery/doorButtons/vaultButton,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -7533,11 +6986,6 @@
 "iQu" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
-"iQV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
 "iRe" = (
 /obj/machinery/washing_machine,
@@ -7759,15 +7207,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"jeT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	layer = 4.1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/vault)
 "jhe" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -7826,23 +7265,6 @@
 	icon_state = "verticalrightborderlefttop"
 	},
 /area/f13/wasteland)
-"jmp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/item/book/granter/trait/chemistry,
-/obj/item/reagent_containers/dropper,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
-"jmG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "jnu" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -7899,17 +7321,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"jte" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "juI" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
@@ -8325,20 +7736,6 @@
 /obj/item/ammo_casing/a762,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"jYN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/clothing/mask/surgical{
-	pixel_y = -4
-	},
-/obj/item/healthanalyzer/advanced,
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "kaB" = (
 /obj/machinery/computer/security{
 	network = list("vault")
@@ -8427,13 +7824,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/tunnel)
-"kfe" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy{
-	faction = list("raider")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "kfq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -8478,21 +7868,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/underground/cave)
-"kjy" = (
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
-"kjz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "kjM" = (
 /obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
@@ -8508,14 +7883,6 @@
 /obj/machinery/mineral/processing_unit,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
-"kky" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider,
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "kkC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8611,11 +7978,6 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"koK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "kpf" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8770,13 +8132,6 @@
 	},
 /turf/open/floor/pod,
 /area/f13/underground/cave)
-"kvV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 6
-	},
-/area/f13/vault)
 "kws" = (
 /obj/structure/table/wood,
 /obj/item/grenade/empgrenade,
@@ -8891,15 +8246,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
-"kFf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/vault)
 "kFl" = (
 /obj/machinery/door/airlock/public/glass{
@@ -9124,11 +8470,6 @@
 "kRy" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"kSs" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/ranged/boss,
-/turf/open/floor/wood,
-/area/f13/vault)
 "kSv" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -9374,22 +8715,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"lhi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/snack,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "lhl" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"lhz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "lhP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -9442,11 +8773,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"loM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "lqa" = (
 /obj/structure/flora/junglebush,
 /turf/open/water,
@@ -9503,16 +8829,6 @@
 	id = 920
 	},
 /turf/open/floor/engine,
-/area/f13/vault)
-"lts" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath,
-/obj/item/storage/box/gloves,
-/obj/item/roller,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "ltA" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -9611,17 +8927,6 @@
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
-"lze" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 4;
-	pixel_y = -16
-	},
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "lzU" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -9669,17 +8974,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"lGh" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
 "lGv" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
@@ -9796,22 +9090,6 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
-"lOD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
-"lPn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "lPy" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -9883,14 +9161,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"lWL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/raider/ranged{
-	pixel_x = -30;
-	spawn_time = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "lXy" = (
 /obj/structure/closet/wardrobe,
 /obj/item/stock_parts/cell/ammo/mfc,
@@ -9997,11 +9267,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
-"mbC" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
 "mck" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -10021,13 +9286,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
-"mcS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wallframe/camera,
-/obj/structure/barricade/sandbags,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "mdB" = (
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -10098,12 +9356,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"mhR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/wood,
-/area/f13/vault)
 "mig" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -10153,11 +9405,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"mlL" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "mmy" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -10166,13 +9413,6 @@
 	},
 /obj/structure/fermenting_barrel,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
-"mnC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs{
-	icon = 'icons/obj/stairs.dmi'
-	},
 /area/f13/vault)
 "mnN" = (
 /obj/machinery/door/airlock/science/glass{
@@ -10259,13 +9499,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"mse" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy{
-	faction = list("raider")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "mso" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10325,14 +9558,6 @@
 "muE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"muV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "mvi" = (
 /obj/machinery/door/airlock/medical{
@@ -10494,11 +9719,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/underground/cave)
-"mBJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "mBK" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	faction = list("wastebot")
@@ -10531,11 +9751,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"mCR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "mDe" = (
 /obj/structure/debris/v3,
 /turf/closed/indestructible/vaultdoor,
@@ -10657,11 +9872,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"mIs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/vault)
 "mIW" = (
 /obj/structure/rack,
 /obj/item/clothing/under/syndicate/combat,
@@ -10883,12 +10093,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"mUl" = (
-/obj/structure/decoration/smokeold{
-	pixel_x = 32
-	},
-/turf/closed/indestructible/vaultdoor,
-/area/f13/vault)
 "mUu" = (
 /obj/item/storage/trash_stack,
 /obj/machinery/light,
@@ -10897,11 +10101,6 @@
 "mWs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
-"mWV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "mXh" = (
@@ -10927,33 +10126,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"mZI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
-"naM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/machinery/light/broken{
-	pixel_x = 16
-	},
-/obj/item/reagent_containers/food/drinks/bottle/instacoffee{
-	pixel_x = -8
-	},
-/obj/item/crafting/coffee_pot{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
 /area/f13/vault)
 "nbj" = (
 /obj/machinery/door/poddoor{
@@ -11009,11 +10181,6 @@
 "nfs" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/vault)
-"ngv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "nhA" = (
 /obj/machinery/door/airlock/science/glass{
@@ -11112,12 +10279,6 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
-"nmo" = (
-/obj/item/wallframe/camera,
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "nms" = (
 /obj/machinery/door/airlock{
 	name = "Bar Backroom"
@@ -11175,12 +10336,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/carpet/black,
-/area/f13/vault)
-"nrm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "nrL" = (
 /obj/structure/bookcase/manuals/medical,
@@ -11461,11 +10616,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"nJV" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "nKa" = (
 /obj/machinery/shower{
 	dir = 4
@@ -11552,26 +10702,6 @@
 	},
 /obj/item/stack/sheet/plasteel/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
-"nPg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/freezer/meat{
-	anchored = 1
-	},
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
 "nPp" = (
 /obj/machinery/light,
@@ -11735,27 +10865,12 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"nZz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/f13/vault)
 "nZA" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/vault)
-"nZK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/nest/raider/ranged{
-	pixel_x = -30;
-	spawn_time = 10
-	},
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
 "nZS" = (
 /obj/machinery/recharge_station,
@@ -11925,11 +11040,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"oiW" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider,
-/turf/open/floor/plasteel/dark,
-/area/f13/vault)
 "ojG" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -12420,12 +11530,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"oTI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "oTJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -12447,14 +11551,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"oUf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/obj/machinery/door/poddoor{
-	id = "vaultelevator"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "oUE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
@@ -12490,11 +11586,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
-"oWn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/wood,
-/area/f13/vault)
 "oWt" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
@@ -12634,10 +11725,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
-"pgB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "phh" = (
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
@@ -12770,21 +11857,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"pmK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/book/granter/trait/lowsurgery,
-/obj/item/clipboard{
-	pixel_x = 36
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
-"pnm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/defibrillator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "pny" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/water,
@@ -12838,17 +11910,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"ppw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/left,
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "ppF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
@@ -12878,20 +11939,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"pss" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "psy" = (
 /obj/structure/fence{
 	dir = 1;
@@ -12950,10 +11997,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
-"pvd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/vault)
 "pvG" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12987,16 +12030,6 @@
 	name = "Hydroponics"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
-"pwK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wallframe/camera,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/nest/raider/ranged{
-	pixel_x = -30;
-	spawn_time = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
 "pxp" = (
 /obj/item/radio/intercom{
@@ -13089,17 +12122,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"pBG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/mob/living/simple_animal/hostile/wolf/alpha{
-	faction = list("raider")
-	},
-/mob/living/simple_animal/hostile/raider,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "pBV" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -13116,15 +12138,6 @@
 "pCA" = (
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/vault)
-"pDt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/optable,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
 "pEA" = (
 /obj/structure/window/reinforced,
@@ -13166,11 +12179,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
-"pJb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "pKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13297,11 +12305,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"pTq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/departments/botany,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/vault)
 "pTK" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
@@ -13362,11 +12365,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
-"pWL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "pXf" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
@@ -13652,20 +12650,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
-"qom" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/decoration/vent,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
 "qqa" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -13684,16 +12668,6 @@
 /obj/item/lighter/greyscale,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
-"qrL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/structure/decoration/rag,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "qrP" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -13786,29 +12760,6 @@
 "qxK" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
-"qxW" = (
-/obj/structure/rack,
-/obj/item/stock_parts/capacitor/adv,
-/obj/item/stock_parts/capacitor/adv,
-/obj/item/stock_parts/manipulator/pico,
-/obj/item/stock_parts/manipulator/pico,
-/obj/item/stock_parts/manipulator/pico,
-/obj/item/stock_parts/scanning_module/adv,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
 /area/f13/vault)
 "qyv" = (
 /obj/structure/table/wood,
@@ -14153,14 +13104,6 @@
 	dir = 4
 	},
 /area/f13/vault)
-"qQg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/middle,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "qQG" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing/corner{
@@ -14219,14 +13162,6 @@
 "qUj" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
-"qVg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
 "qVA" = (
 /obj/structure/window/plastitanium,
@@ -14293,15 +13228,6 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
 /area/f13/underground/cave)
-"qWz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper/pamphlet{
-	desc = "a trashy prewar comic book";
-	name = "prewar comic book"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/f13/vault)
 "qWZ" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/dark,
@@ -14362,21 +13288,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
-"rbK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "rbT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"rcI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/item/storage/box/papersack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "rcL" = (
 /obj/item/rack_parts,
 /obj/item/storage/trash_stack,
@@ -14398,20 +13314,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"rdX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 4
-	},
-/area/f13/vault)
-"ref" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/sandbags,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "ren" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/candle/infinite{
@@ -14502,10 +13404,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"rib" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "rij" = (
 /obj/machinery/door/poddoor{
 	id = "lock2"
@@ -14552,11 +13450,6 @@
 	pixel_y = 11
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
-"rkZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "rlu" = (
 /obj/structure/chair/comfy/black,
@@ -14730,13 +13623,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"ruB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/right{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "ruT" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
@@ -14857,22 +13743,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/underground/cave)
-"rBN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/right,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
-"rBR" = (
-/obj/structure/rack,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/assembly/timer,
-/obj/item/mining_scanner,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/vault)
 "rBT" = (
 /obj/structure/chair/stool/bar{
 	desc = "The place you sit when all hope is lost.";
@@ -14907,11 +13777,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"rCV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "rDh" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -14976,14 +13841,6 @@
 /obj/item/stack/crafting/electronicparts/three,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"rGd" = (
-/obj/structure/rack,
-/obj/item/screwdriver/power,
-/obj/item/wirecutters/power,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "rGw" = (
 /obj/structure/rack{
 	dir = 8;
@@ -15022,11 +13879,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"rGY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "rHD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -15149,12 +14001,6 @@
 	},
 /turf/open/floor/plating/f13,
 /area/f13/vault)
-"rPu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/microwave/stove,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
 "rQl" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15172,11 +14018,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
-"rRC" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "rSc" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -15238,18 +14079,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"rXW" = (
-/obj/structure/mopbucket,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/obj/effect/decal/cleanable/insectguts,
-/obj/item/caution{
-	pixel_x = -8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/vault)
 "rYh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/nest/radroach,
@@ -15302,11 +14131,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"scL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "sdJ" = (
 /obj/structure/simple_door/house,
 /turf/closed/mineral/random/low_chance,
@@ -15329,15 +14153,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"sgg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
-	},
-/obj/structure/curtain,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/vault)
 "shT" = (
 /obj/machinery/light{
 	dir = 8
@@ -15363,15 +14178,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"siH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "siS" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/f13{
@@ -15382,15 +14188,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"sjc" = (
-/obj/machinery/door/airlock/science/glass{
-	name = "Science";
-	req_access_txt = "31"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/rag,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
 "sje" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -15511,19 +14308,6 @@
 /obj/item/stack/f13Cash/random/med,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
-"ssW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "suu" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -15564,13 +14348,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"swS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "swU" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -15608,11 +14385,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"sAa" = (
-/obj/machinery/door/airlock/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
 "sAk" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd5";
@@ -15745,16 +14517,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
-"sHu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid{
-	pixel_x = 10;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "sIU" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -15826,21 +14588,11 @@
 	dir = 4
 	},
 /area/f13/vault)
-"sPe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/jukebox,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "sPs" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"sPR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "sQG" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	faction = list("wastebot")
@@ -16221,19 +14973,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"ttu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "ttv" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -16291,12 +15030,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"tvD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "txu" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -16372,20 +15105,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"tCC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/pizzabox/meat,
-/obj/item/reagent_containers/glass/rag{
-	pixel_y = 8
-	},
-/obj/structure/sign/plaques/kiddie{
-	desc = "A faded sign listing all the less-than-healthy fast foods that were sold here before the war";
-	name = "fast food menu";
-	pixel_y = 31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "tDi" = (
 /obj/structure/chair/bench,
 /obj/machinery/light{
@@ -16419,20 +15138,6 @@
 "tEQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
-/area/f13/vault)
-"tET" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 9
-	},
 /area/f13/vault)
 "tFW" = (
 /obj/structure/campfire/stove,
@@ -16590,14 +15295,6 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"tRO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "tRT" = (
 /obj/structure/chair{
 	dir = 1
@@ -16715,13 +15412,6 @@
 /obj/item/toy/cards/singlecard,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"uaG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "ubu" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/pod,
@@ -16815,13 +15505,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
-"ukA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/vault)
 "ukN" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -16875,11 +15558,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
-/area/f13/vault)
-"unR" = (
-/obj/machinery/door/airlock/maintenance/abandoned,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "unX" = (
 /obj/structure/simple_door/house{
@@ -17023,27 +15701,6 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
-"uwZ" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
-/obj/structure/nest/raider/ranged{
-	pixel_x = -30;
-	spawn_time = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
-"uxD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "uym" = (
 /obj/item/wirerod,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -17058,14 +15715,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"uyy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/seed_extractor,
-/obj/machinery/light/broken{
-	pixel_x = 16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "uyN" = (
 /obj/structure/sign/departments/examroom,
 /turf/closed/wall/r_wall/f13vault{
@@ -17121,13 +15770,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
-"uCA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "uCE" = (
 /obj/structure/chair{
 	dir = 4
@@ -17158,11 +15800,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"uDq" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "uEk" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -17180,14 +15817,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"uGE" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = 33
-	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "uIJ" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -17300,13 +15929,6 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"uLu" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/wolf/alpha{
-	faction = list("raider")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
 "uMj" = (
 /obj/structure/chair/left,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -17318,11 +15940,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"uMK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/vault)
 "uNg" = (
 /obj/structure/table,
 /obj/item/crafting/board,
@@ -17570,14 +16187,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/underground/cave)
-"vcV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/barrel/four,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "vdq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17636,22 +16245,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"vgZ" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/obj/item/toy/plush/beeplushie,
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/obj/structure/sign/poster/contraband/pinup_couch{
-	pixel_y = 31
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "vhE" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -17693,14 +16286,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"viV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/light,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "vjd" = (
 /obj/structure/toilet,
 /turf/open/floor/f13{
@@ -17968,15 +16553,6 @@
 	dir = 9
 	},
 /area/f13/vault)
-"vyb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/razor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/vault)
 "vyk" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /obj/effect/decal/cleanable/dirt,
@@ -18075,11 +16651,6 @@
 	},
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"vEo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "vES" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -18120,13 +16691,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/bunker)
-"vIa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	name = "Hydroponics"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/vault)
 "vJb" = (
 /obj/machinery/door/airlock/public/glass{
 	req_access_txt = "31"
@@ -18246,10 +16810,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/vault)
-"vRT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "vSA" = (
 /obj/structure/rack,
@@ -18394,12 +16954,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"wbf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "wbl" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
@@ -18504,11 +17058,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"whP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "wjA" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18868,15 +17417,6 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
-"wAC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
 "wAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -18937,12 +17477,6 @@
 	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
-"wFN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
 "wFT" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/hostile/cazador/young,
@@ -19326,22 +17860,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"xhu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fireaxecabinet{
-	pixel_x = 33
-	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
-"xip" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/prewar/poster72,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "xiC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19475,13 +17993,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"xqL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fireaxecabinet{
-	pixel_x = 33
-	},
-/turf/open/floor/wood,
-/area/f13/vault)
 "xqT" = (
 /obj/structure/chair{
 	dir = 8
@@ -19525,13 +18036,6 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/vault)
-"xtq" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/wolf/alpha{
-	faction = list("raider")
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "xtU" = (
 /obj/machinery/door/airlock/grunge/abandoned,
@@ -19620,11 +18124,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
-"xyJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "xyU" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -19721,12 +18220,6 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"xCH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_master/advanced,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/vault)
 "xDq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19994,13 +18487,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/bunker)
-"xUy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/rag,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/vault)
 "xUK" = (
 /obj/structure/sign/departments/science,
 /turf/closed/wall/r_wall/f13/vault,
@@ -20033,11 +18519,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
-"xWF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/vault)
 "xXh" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20056,26 +18537,11 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"xYT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/left{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/vault)
 "xYZ" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/vault)
-"xZn" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/radroach,
-/turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
 "yaD" = (
 /obj/structure/chair,
@@ -20146,11 +18612,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/vault)
-"ycL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
 "ycR" = (
 /obj/structure/closet/crate/bin,
@@ -39535,23 +37996,23 @@ heT
 heT
 heT
 heT
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-fab
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-hJL
-hJL
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -39791,25 +38252,25 @@ heT
 heT
 heT
 heT
-xsH
-eqU
-bZo
-mAN
-nJV
-pwK
-mlL
-mAN
-lOD
-qom
-mAN
-aXC
-rGd
-hQs
-mAN
-tET
-aob
-fRh
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -40048,25 +38509,25 @@ heT
 heT
 heT
 heT
-xsH
-vgZ
-qWz
-afE
-awO
-pBG
-uMK
-iOm
-vyb
-kky
-mAN
-rXW
-gyG
-gqF
-ftQ
-qxW
-oiW
-fFS
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -40305,25 +38766,25 @@ heT
 heT
 heT
 heT
-xsH
-huH
-mAN
-uGE
-wAC
-cOX
-ref
-mAN
-sAa
-mAN
-mAN
-huH
-mAN
-unR
-mAN
-rBR
-eLG
-ewi
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -40562,25 +39023,25 @@ heT
 heT
 heT
 heT
-xsH
-gIA
-bZo
-xsH
-dEU
-rgv
-iQV
-rgv
-awO
-rgv
-uwZ
-nmo
-awO
-lhz
-sjc
-ukA
-xtq
-fFN
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -40819,25 +39280,25 @@ heT
 heT
 heT
 heT
-xsH
-bCA
-fUD
-afE
-lhz
-awO
-lhz
-awO
-lhz
-uLu
-rbK
-mbC
-lhz
-ciO
-dDR
-iMr
-rdX
-kvV
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -41076,25 +39537,25 @@ heT
 heT
 heT
 heT
-xsH
-huH
-mAN
-mAN
-bHX
-kjz
-uDq
-mAN
-mAN
-mAN
-mAN
-kjy
-kcN
-kcN
-iuD
-mAN
-huH
-mAN
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -41333,25 +39794,25 @@ heT
 heT
 heT
 heT
-xsH
-jYN
-pnm
-clD
-fWx
-fWx
-iMj
-xCH
-whP
-gjL
-heW
-xUy
-bGb
-lhz
-rgv
-gTe
-lPn
-gsC
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -41590,25 +40051,25 @@ heT
 heT
 heT
 heT
-xsH
-pDt
-cJK
-eoT
-xhu
-oTI
-dEy
-uxD
-idq
-rGY
-sPR
-fWx
-ttu
-rgv
-nrm
-fWx
-fWx
-fWx
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -41847,25 +40308,25 @@ heT
 heT
 heT
 heT
-xsH
-aBy
-fiH
-lts
-fWx
-vRT
-qrL
-pgB
-cxg
-fsI
-jmp
-fWx
-loM
-rgv
-fWx
-mBJ
-rib
-ycL
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -42104,25 +40565,25 @@ heT
 heT
 heT
 heT
-xsH
-iMj
-sgg
-avl
-tRO
-vRT
-fWx
-fWx
-fWx
-fWx
-fWx
-gqE
-scL
-vEo
-iMj
-pJb
-rRC
-uyy
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -42361,25 +40822,25 @@ heT
 heT
 heT
 heT
-xsH
-wFN
-ibl
-vRT
-ibl
-fWx
-rCV
-lhz
-rgv
-lhz
-rgv
-rgv
-rgv
-tvD
-pTq
-ssW
-rib
-iyd
-adI
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -42618,25 +41079,25 @@ heT
 heT
 heT
 heT
-mUl
-jte
-pmK
-vRT
-vRT
-iMj
-ama
-rgv
-rgv
-rgv
-muV
-lhz
-lhz
-lhz
-vIa
-rib
-rib
-iyd
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -42875,25 +41336,25 @@ heT
 heT
 heT
 heT
-xsH
-viV
-uCA
-iKU
-ibl
-bAE
-rgv
-lhz
-gqE
-fWx
-fWx
-fWx
-fWx
-fWx
-fWx
-pss
-lze
-iyd
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -43132,25 +41593,25 @@ heT
 heT
 heT
 heT
-xsH
-eXH
-sHu
-koK
-hRh
-fWx
-mcS
-rgv
-fWx
-rBN
-rcI
-xYT
-fMC
-nZK
-cqc
-fWx
-iMj
-fWx
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -43389,25 +41850,25 @@ heT
 heT
 heT
 heT
-xsH
-fWx
-fWx
-fWx
-fWx
-rgv
-rgv
-cUk
-xip
-qQg
-wbf
-crD
-wbf
-cuk
-cuk
-pvd
-nZz
-siH
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -43646,25 +42107,25 @@ heT
 heT
 heT
 heT
-xsH
-gkP
-mnC
-eNW
-lWL
-rgv
-rgv
-rgv
-fWx
-ppw
-xyJ
-ruB
-swS
-eNv
-pWL
-mhR
-nZz
-jmG
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -43903,25 +42364,25 @@ heT
 heT
 heT
 heT
-xsH
-vcV
-bRt
-uaG
-rgv
-kfe
-lhz
-rgv
-dsr
-cuk
-cuk
-cbY
-cuk
-mCR
-pWL
-hyg
-kSs
-naM
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -44160,25 +42621,25 @@ heT
 heT
 heT
 heT
-xsH
-fWx
-fWx
-fWx
-rkZ
-rgv
-rgv
-iNt
-fWx
-dEi
-pWL
-pWL
-pWL
-mse
-pWL
-iPg
-xqL
-oWn
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -44417,25 +42878,25 @@ heT
 heT
 heT
 heT
-xsH
-jeT
-aTp
-aTp
-fWx
-ama
-kfe
-rgv
-lhi
-fWx
-tCC
-eOE
-gyK
-cuk
-sPe
-fWx
-fWx
-iMj
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -44674,25 +43135,25 @@ heT
 heT
 heT
 heT
-xsH
-jeT
-aTp
-aTp
-fWx
-fId
-rgv
-rgv
-gqE
-fWx
-mZI
-gYU
-bRu
-xWF
-iMj
-cPm
-nPg
-lGh
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -44931,25 +43392,25 @@ heT
 heT
 heT
 heT
-xsH
-ilm
-kFf
-mIs
-oUf
-rgv
-rgv
-rgv
-rCV
-fWx
-rPu
-mWV
-ngv
-bCR
-fjD
-feM
-xZn
-qVg
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -45189,23 +43650,23 @@ heT
 heT
 heT
 heT
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
-xsH
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -9087,7 +9087,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/anvil,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dWH" = (
@@ -18689,10 +18688,6 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"hNz" = (
-/obj/machinery/workbench/forge,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "hNC" = (
 /obj/machinery/door/poddoor{
 	id = "vaultelevator"
@@ -45218,7 +45213,6 @@
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
 	},
-/obj/machinery/door/unpowered/securedoor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tvE" = (
@@ -100369,10 +100363,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+gaV
+gaV
+gaV
+ggK
 tVe
 ggK
 ggK
@@ -100625,11 +100619,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gaV
+iAU
+rjE
+rjE
+gaV
 dWE
 ggK
 vpD
@@ -100882,12 +100876,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-hNz
+gaV
+iAU
+rjE
+rjE
+gaV
+ggK
 ggK
 kSa
 plT
@@ -101139,11 +101133,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gaV
+lCc
+imR
+mRD
+hNC
 ggK
 ggK
 ggK
@@ -101397,10 +101391,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+gaV
+gaV
+gaV
+gAs
 wnA
 bfN
 bfN

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -215,6 +215,18 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"ahu" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "ahw" = (
 /obj/machinery/shower{
 	dir = 8
@@ -246,6 +258,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/dorms)
+"aiL" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Science";
+	req_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/underground/enclave_base)
 "aiQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rd{
@@ -279,6 +300,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
+"ajp" = (
+/obj/item/clothing/glasses/meson,
+/obj/item/pickaxe/drill,
+/obj/item/t_scanner/adv_mining_scanner,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "ajG" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/lattice/catwalk,
@@ -561,9 +590,6 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood/dorms)
-"arc" = (
-/turf/closed/wall/r_wall,
-/area/f13/caves)
 "ase" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /obj/structure/rack,
@@ -803,6 +829,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/circuit/f13_blue,
 /area/f13/brotherhood/dorms)
+"ayM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/aug_manipulator,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "azj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -865,6 +899,21 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/circuit/f13_blue,
 /area/f13/brotherhood/dorms)
+"aAL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
+"aAP" = (
+/obj/structure/ore_box,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "aAX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/f13_blue,
@@ -902,11 +951,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"aBI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/jukebox,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/enclave_base)
 "aBN" = (
 /obj/structure/sign/painting/library_secure{
 	persistence_id = "brotherhood_secure";
@@ -1284,15 +1328,6 @@
 	smooth = 1
 	},
 /area/f13/brotherhood/operating)
-"aMF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "aNc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1580,6 +1615,13 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"aXv" = (
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "aXw" = (
 /obj/item/assembly/signaler{
 	code = 2;
@@ -2174,6 +2216,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"boB" = (
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "boC" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -2516,17 +2564,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
-"byF" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "byI" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt{
@@ -2623,16 +2660,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"bAM" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "bBc" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -2813,12 +2840,27 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/dorms)
+"bGZ" = (
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "bHm" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bHn" = (
+/obj/machinery/workbench,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "bHp" = (
 /turf/open/floor/circuit/f13_red,
 /area/f13/brotherhood/dorms)
@@ -2894,11 +2936,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"bJv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/underground/enclave_base)
 "bJx" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -3007,12 +3044,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"bMC" = (
-/obj/structure/frame/machine,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "bMH" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight,
@@ -3328,16 +3359,6 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"bVL" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "bVY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -3486,6 +3507,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/dorms)
+"can" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "caw" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/briefcase,
@@ -3757,6 +3783,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
+"cjc" = (
+/obj/structure/rack,
+/obj/item/storage/belt,
+/obj/item/storage/belt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "cjg" = (
 /obj/structure/window/fulltile/ruins,
 /obj/structure/barricade/bars,
@@ -3778,16 +3811,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
-"cks" = (
-/obj/machinery/computer/rdconsole/core/vault,
-/obj/structure/sign/poster/official/science{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "ckx" = (
 /obj/machinery/chem_dispenser/drinks{
 	dir = 4;
@@ -4063,11 +4086,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"csu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/underground/enclave_base)
 "csw" = (
 /obj/structure/rack,
 /obj/item/stack/crafting/electronicparts/five,
@@ -4823,11 +4841,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
-"cLF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/processor,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/underground/enclave_base)
 "cLJ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -4953,13 +4966,6 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"cPY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/enclave_base)
 "cQc" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -5115,12 +5121,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"cSW" = (
-/obj/machinery/door/window/brigdoor/security/cell/northleft{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "cSY" = (
 /turf/open/water,
 /area/f13/caves)
@@ -5208,7 +5208,10 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"cVa" = (
+"cUR" = (
+/obj/structure/showcase/horrific_experiment{
+	icon_state = "pod_1"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -5339,6 +5342,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/armory)
+"cZy" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/underground/enclave_base)
 "cZA" = (
 /obj/machinery/telecomms/server/presets/vault,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -5605,13 +5612,6 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"dih" = (
-/obj/machinery/door/airlock/science/glass{
-	name = "Science";
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "dii" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
@@ -5776,14 +5776,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
-"dlL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/freezer,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/underground/enclave_base)
 "dlU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5805,6 +5797,14 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
+"dmt" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach{
+	faction = list("raider")
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "dmH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -6018,29 +6018,6 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"drx" = (
-/obj/structure/rack,
-/obj/item/stock_parts/capacitor/adv,
-/obj/item/stock_parts/capacitor/adv,
-/obj/item/stock_parts/manipulator/pico,
-/obj/item/stock_parts/manipulator/pico,
-/obj/item/stock_parts/manipulator/pico,
-/obj/item/stock_parts/scanning_module/adv,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/item/stock_parts/matter_bin/super,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
-/area/f13/underground/enclave_base)
 "drK" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light/small/broken{
@@ -6083,6 +6060,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"dsM" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 10
+	},
+/area/f13/underground/enclave_base)
 "dtk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -6157,13 +6143,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"dwj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/underground/enclave_base)
 "dwn" = (
 /turf/open/floor/f13{
 	dir = 8;
@@ -6231,6 +6210,13 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"dyh" = (
+/obj/structure/showcase/horrific_experiment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "dyv" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -6323,16 +6309,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
-"dAs" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/underground/enclave_base)
 "dAI" = (
 /obj/machinery/light/fo13colored/Aqua{
 	brightness = 3;
@@ -6656,16 +6632,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
-"dIW" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "dJh" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/chemistry{
@@ -6726,10 +6692,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"dLq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/f13,
-/area/f13/underground/enclave_base)
 "dLs" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -6805,6 +6767,11 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/tunnel)
+"dNT" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "dOb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -6911,6 +6878,13 @@
 /obj/item/reagent_containers/food/snacks/burger/rib,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"dRz" = (
+/obj/structure/rack,
+/obj/item/mop/advanced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/broom,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "dRA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7422,6 +7396,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"eeL" = (
+/obj/item/pickaxe/drill,
+/obj/item/clothing/glasses/meson,
+/obj/item/t_scanner/adv_mining_scanner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "eeM" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bosengineaccess";
@@ -7525,6 +7507,11 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/den)
+"ehe" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/underground/enclave_base)
 "ehk" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/wreck/trash/machinepile,
@@ -7621,6 +7608,13 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"ejA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "ejC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7813,6 +7807,25 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operating)
+"eoU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/machinery/light/broken{
+	pixel_x = 16
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee{
+	pixel_x = -8
+	},
+/obj/item/crafting/coffee_pot{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "epg" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustysolid"
@@ -7942,14 +7955,6 @@
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/brotherhood/operations)
-"esS" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach{
-	faction = list("raider")
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/underground/enclave_base)
 "esX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/right{
@@ -8652,11 +8657,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
-"eLo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/enclave_base)
 "eLq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -9044,6 +9044,29 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/dorms)
+"fad" = (
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "fai" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -9118,6 +9141,13 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
+"fcS" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "fcV" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -9308,6 +9338,18 @@
 	},
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/brotherhood/mining)
+"fix" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "fiI" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
@@ -9521,6 +9563,16 @@
 /obj/structure/nest/gecko,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
+"fol" = (
+/obj/machinery/computer/rdconsole/core/vault,
+/obj/structure/sign/poster/official/science{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "fon" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/ash,
@@ -9631,6 +9683,20 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"fqf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "fqz" = (
 /obj/structure/lattice{
 	density = 1
@@ -9872,6 +9938,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"fwh" = (
+/obj/structure/chair/e_chair,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "fws" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -10043,6 +10113,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/underground/enclave_base)
+"fAE" = (
+/obj/machinery/rnd/production/protolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/underground/enclave_base)
 "fAJ" = (
 /obj/effect/turf_decal/caution/stand_clear/white{
@@ -10228,14 +10305,15 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
-"fEX" = (
-/obj/structure/chair/e_chair,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "fGt" = (
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"fGw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "fGK" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -10243,11 +10321,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
-"fGL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/underground/enclave_base)
 "fGW" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -10359,18 +10432,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"fJO" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/underground/enclave_base)
 "fJQ" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
@@ -10544,20 +10605,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"fOL" = (
-/obj/structure/mopbucket,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/obj/item/caution{
-	pixel_x = -8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/underground/enclave_base)
 "fOZ" = (
 /obj/structure/simple_door/metal/iron,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -10736,11 +10783,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/underground/enclave_base)
-"fSX" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
 /area/f13/underground/enclave_base)
 "fTe" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -11584,13 +11626,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"gty" = (
-/obj/machinery/rnd/server/vault,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "gtS" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
@@ -11611,6 +11646,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"gux" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "guz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/large,
@@ -11687,11 +11728,6 @@
 	},
 /turf/open/water,
 /area/f13/brotherhood/rnd)
-"gwZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "gxd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -12441,6 +12477,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"gPM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "gPO" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -12452,12 +12493,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"gQi" = (
-/obj/effect/decal/cleanable/dirt,
+"gQq" = (
+/obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/underground/enclave_base)
 "gQx" = (
 /obj/machinery/button/door{
@@ -12674,6 +12718,16 @@
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"gUE" = (
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/underground/enclave_base)
 "gVb" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/f13{
@@ -12811,6 +12865,29 @@
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gYj" = (
+/obj/structure/rack,
+/obj/item/stock_parts/capacitor/adv,
+/obj/item/stock_parts/capacitor/adv,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/scanning_module/adv,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/underground/enclave_base)
 "gYt" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -12966,12 +13043,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"hjo" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "hjD" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13{
@@ -13009,6 +13080,13 @@
 "hkD" = (
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/tunnel)
+"hkF" = (
+/obj/structure/fans/tiny,
+/obj/structure/fireaxecabinet{
+	pixel_x = 33
+	},
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "hkR" = (
 /obj/machinery/door/airlock/grunge,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -13053,14 +13131,6 @@
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
-"hmv" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/aug_manipulator,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/underground/enclave_base)
 "hmM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightlifter,
@@ -13418,12 +13488,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"hAd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
-/area/f13/underground/enclave_base)
 "hAl" = (
 /obj/structure/destructible/clockwork/wall_gear,
 /obj/machinery/light/floor,
@@ -13519,6 +13583,9 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"hDQ" = (
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "hEe" = (
 /obj/structure/falsewall/reinforced{
 	layer = 3
@@ -13561,13 +13628,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"hGR" = (
-/obj/machinery/door/airlock/vault{
-	req_one_access_txt = "134"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "hHs" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -13744,13 +13804,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"hMX" = (
-/obj/machinery/workbench/advanced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 10
-	},
-/area/f13/underground/enclave_base)
 "hNk" = (
 /obj/machinery/light/small,
 /obj/structure/curtain{
@@ -13795,13 +13848,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
-"hOn" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "hOr" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -13867,6 +13913,11 @@
 /obj/structure/flora/junglebush/large,
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
+"hPK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "hQf" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -14256,6 +14307,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
+"ida" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chalkboard,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/underground/enclave_base)
 "ids" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/handrail/g_central{
@@ -14398,6 +14458,10 @@
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"ijb" = (
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "iji" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/f13{
@@ -14848,23 +14912,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
-"iAM" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/machine/mechfab,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "iAR" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
@@ -14947,6 +14994,17 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
+"iEi" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "iEs" = (
 /obj/effect/decal/fakelattice{
 	layer = 2.0
@@ -15040,6 +15098,11 @@
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"iLe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "iLx" = (
 /obj/structure/table{
 	layer = 2.9
@@ -15115,6 +15178,24 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
+"iNw" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "iOd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16236,14 +16317,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/archives)
-"jyL" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "jyQ" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -16266,12 +16339,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
-"jzW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "jAd" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16434,6 +16501,11 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
+"jHZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "jIc" = (
 /obj/structure/table/wood/settler,
 /obj/item/hatchet,
@@ -16461,13 +16533,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
-"jIC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/left{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/enclave_base)
 "jJe" = (
 /obj/structure/window/reinforced/spawner/north{
 	dir = 8
@@ -16475,6 +16540,17 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"jJj" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
+"jJm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "jJr" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt{
@@ -17272,13 +17348,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"kmH" = (
-/obj/machinery/mech_bay_recharge_port,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "kmM" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -17353,6 +17422,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"koM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "kpd" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17364,6 +17439,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"kpt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "kpC" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17807,12 +17887,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"kHo" = (
-/obj/machinery/vending/robotics,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "kHD" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -17851,13 +17925,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"kJj" = (
-/obj/machinery/rnd/production/protolathe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "kJq" = (
 /obj/structure/bed,
 /obj/structure/spider/stickyweb,
@@ -18228,6 +18295,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
+"kXX" = (
+/obj/machinery/door/airlock/vault{
+	req_one_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "kYT" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -18246,14 +18320,6 @@
 "kZZ" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood/mining)
-"laL" = (
-/obj/structure/rack,
-/obj/item/screwdriver/power,
-/obj/item/wirecutters/power,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/underground/enclave_base)
 "laN" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -18451,6 +18517,12 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"lfU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "lgv" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /turf/open/floor/plasteel/f13{
@@ -18536,13 +18608,6 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"liY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/right{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/enclave_base)
 "ljc" = (
 /obj/item/flag/bos,
 /obj/machinery/light{
@@ -18576,6 +18641,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/operating)
+"ljD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "lkf" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = 33
@@ -18621,6 +18693,11 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"llq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "llt" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18647,28 +18724,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"lmp" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/underground/enclave_base)
-"lms" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 9;
-	pixel_y = 19
-	},
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "lmB" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/decoration/rag,
@@ -18725,14 +18780,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lpc" = (
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/underground/enclave_base)
 "lph" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -18755,29 +18802,6 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
-"lps" = (
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/underground/enclave_base)
 "lpI" = (
 /obj/item/storage/trash_stack,
 /obj/structure/destructible/tribal_torch/lit,
@@ -18798,15 +18822,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"lpZ" = (
-/obj/structure/showcase/horrific_experiment{
-	icon_state = "pod_1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "lqf" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/ruins,
@@ -18944,11 +18959,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"luY" = (
-/obj/item/soap,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "lvc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -18975,12 +18985,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
-"lwj" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "lwv" = (
 /obj/structure/table/wood/settler,
 /obj/item/gun/ballistic/revolver/caravan_shotgun,
@@ -19383,6 +19387,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"lLG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "lLQ" = (
 /obj/item/reagent_containers/food/snacks/meat/slab/molerat,
 /obj/effect/decal/cleanable/blood,
@@ -19476,6 +19489,16 @@
 /obj/effect/landmark/start/f13/followersdoctor,
 /turf/open/floor/carpet/blue,
 /area/f13/followers)
+"lOM" = (
+/obj/item/paper/crumpled/ruins,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "lPf" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -19847,14 +19870,6 @@
 "mir" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"miu" = (
-/obj/item/clothing/glasses/meson,
-/obj/item/pickaxe/drill,
-/obj/item/t_scanner/adv_mining_scanner,
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "miI" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -20113,13 +20128,6 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/underground/enclave_base)
-"mrH" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
 /area/f13/underground/enclave_base)
 "msn" = (
 /obj/machinery/light{
@@ -20443,19 +20451,6 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"mEY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/underground/enclave_base)
 "mFz" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -20478,11 +20473,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/armory)
-"mGb" = (
-/obj/machinery/autolathe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/underground/enclave_base)
 "mGK" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -20645,6 +20635,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"mLV" = (
+/obj/structure/sign/departments/science,
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "mLW" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -21645,6 +21639,14 @@
 "niU" = (
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/mining)
+"njE" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "njZ" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/chemistry{
@@ -21655,16 +21657,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"nkg" = (
-/obj/structure/ore_box,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "nkh" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small{
@@ -21679,6 +21671,13 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
+"nlo" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "nlz" = (
 /obj/structure/sign/warning{
 	name = "CRUSH HAZARD"
@@ -21794,6 +21793,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"nqc" = (
+/obj/machinery/door/airlock/wood{
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "nqH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21972,13 +21977,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"nwp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/middle{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/enclave_base)
 "nwA" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -22227,13 +22225,6 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
-"nFG" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/underground/enclave_base)
 "nFJ" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -22390,29 +22381,12 @@
 /obj/item/seeds/cannabis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
-"nJG" = (
-/obj/structure/showcase/horrific_experiment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "nJT" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
-"nKQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/enclave_base)
 "nKZ" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
@@ -22917,12 +22891,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"oaJ" = (
-/obj/structure/rack,
-/obj/item/storage/belt,
-/obj/item/storage/belt,
+"oaH" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
 /area/f13/underground/enclave_base)
 "oaP" = (
 /obj/structure/cable{
@@ -23176,11 +23150,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/den)
-"ohL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/underground/enclave_base)
 "ohO" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -23247,6 +23216,14 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"ojt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/freezer,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "oju" = (
 /obj/machinery/light{
 	dir = 8;
@@ -23270,17 +23247,6 @@
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"oke" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/underground/enclave_base)
 "okm" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkrustysolid"
@@ -23694,6 +23660,15 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
+"oAw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/nest/raider/ranged{
+	pixel_x = -30;
+	spawn_time = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "oAW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -23969,6 +23944,18 @@
 	icon_state = "neutraldirtyfull"
 	},
 /area/f13/tunnel)
+"oMn" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
+"oMs" = (
+/obj/item/soap,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "oNi" = (
 /obj/item/radio/intercom{
 	desc = "Is there anyone on the other end? Who's in there?";
@@ -24034,20 +24021,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
-"oPs" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 9
-	},
-/area/f13/underground/enclave_base)
 "oPz" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -24191,6 +24164,15 @@
 /obj/structure/table/survival_pod,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"oSR" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "oTA" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -24361,13 +24343,11 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
-"paJ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/chalkboard,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
+"paG" = (
+/obj/machinery/rnd/server/vault,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
 /area/f13/underground/enclave_base)
 "paO" = (
@@ -24425,11 +24405,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
-"pdO" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/enclave_base)
 "pec" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/chemistry,
@@ -24499,23 +24474,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
-"pgc" = (
-/obj/structure/closet/crate/footlocker,
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "pgt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"pgu" = (
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "pgv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24550,21 +24513,12 @@
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"pik" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/underground/enclave_base)
 "pis" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"piH" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall/r_wall,
-/area/f13/underground/enclave_base)
 "piI" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -24671,12 +24625,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"pnQ" = (
-/obj/structure/table,
-/obj/item/integrated_circuit_printer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/underground/enclave_base)
 "pnV" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -24727,6 +24675,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"ppP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "pqu" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -24991,11 +24946,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"pAk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/underground/enclave_base)
 "pAn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -25119,6 +25069,21 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"pDZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/underground/enclave_base)
+"pEm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "pEF" = (
 /obj/item/instrument/saxophone,
 /obj/structure/rack,
@@ -25417,6 +25382,17 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"pOn" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "pOo" = (
 /obj/structure/rack,
 /obj/item/electropack/shockcollar{
@@ -25561,6 +25537,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pRK" = (
+/obj/machinery/vending/robotics,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "pRM" = (
 /obj/machinery/telecomms/message_server,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -25657,6 +25639,20 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pWu" = (
+/obj/structure/mopbucket,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/item/caution{
+	pixel_x = -8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "pWI" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/r_wall/rust,
@@ -25722,6 +25718,11 @@
 /obj/structure/punching_bag,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pYY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "pYZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/ladder/unbreakable{
@@ -25810,15 +25811,6 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"qbA" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/underground/enclave_base)
 "qbH" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -25971,6 +25963,18 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/den)
+"qgk" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "qgo" = (
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/inside/subway,
@@ -26279,6 +26283,16 @@
 /obj/machinery/pdapainter,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
+"qpg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "qpl" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/mineral/iron,
@@ -26583,10 +26597,6 @@
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"qxW" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/underground/enclave_base)
 "qya" = (
 /obj/structure/table{
 	layer = 2.9
@@ -27459,12 +27469,6 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
-"qYJ" = (
-/obj/machinery/door/airlock/wood{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "qYM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27605,6 +27609,15 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/den)
+"rds" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Science";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "rdL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
@@ -27971,10 +27984,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
-"rwA" = (
-/obj/structure/closet,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "rwE" = (
 /obj/structure/table/wood,
 /obj/structure/spider/stickyweb,
@@ -28292,6 +28301,10 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/water,
 /area/f13/bunker)
+"rFg" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "rFn" = (
 /obj/structure/simple_door/house{
 	icon_state = "glassclosing"
@@ -28307,18 +28320,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"rFu" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/item/radio/intercom{
-	frequency = 1361;
-	name = "Vault Intercom";
-	pixel_y = 30
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "rFB" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/f13/wood,
@@ -28429,9 +28430,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"rKg" = (
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "rKy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -28527,11 +28525,6 @@
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
 /area/f13/caves)
-"rNi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/underground/enclave_base)
 "rNk" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light/small{
@@ -28547,6 +28540,11 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
+"rNA" = (
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
 /area/f13/underground/enclave_base)
 "rNO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28761,16 +28759,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
-"rTb" = (
-/obj/item/paper/crumpled/ruins,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/underground/enclave_base)
 "rTg" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/plating/tunnel{
@@ -28892,6 +28880,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"rYE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "rZw" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
@@ -29075,12 +29067,6 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"sgJ" = (
-/obj/structure/closet/crate/miningcar,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "sgN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29165,6 +29151,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"siM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "sjA" = (
 /obj/structure/closet/crate/large,
 /obj/effect/decal/cleanable/dirt,
@@ -29261,6 +29252,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"soy" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Science";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "spm" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -29712,6 +29710,17 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"sKh" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "sKt" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -29946,6 +29955,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
+"sVA" = (
+/obj/structure/table,
+/obj/item/integrated_circuit_printer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "sVL" = (
 /obj/structure/statue/uranium/nuke,
 /obj/machinery/light{
@@ -29953,25 +29968,29 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"sVM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/nest/raider/ranged{
-	pixel_x = -30;
-	spawn_time = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/enclave_base)
 "sVP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
+"sWZ" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/usscientist,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "sXn" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "aesculapius"
 	},
 /area/f13/brotherhood/operating)
+"sXB" = (
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "sXM" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib4-old"
@@ -30057,10 +30076,6 @@
 "tbu" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/caves)
-"tby" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/underground/enclave_base)
 "tbE" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/mprostitute,
@@ -30174,15 +30189,6 @@
 /obj/item/clothing/head/bio_hood/f13/hazmat,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
-"tho" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "thC" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/hydroponics/constructable,
@@ -30372,6 +30378,23 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/caves)
+"toi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 9;
+	pixel_y = 19
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "top" = (
 /obj/effect/landmark/start/f13/followersvolunteer,
 /turf/open/floor/carpet/blue,
@@ -30506,15 +30529,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"ttc" = (
-/obj/machinery/door/airlock/science/glass{
-	name = "Science";
-	req_access_txt = "134"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/rag,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/enclave_base)
 "tte" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -30655,6 +30669,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
+"tzl" = (
+/obj/structure/closet,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "tzz" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -30839,6 +30857,14 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"tGk" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "tGq" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -30849,6 +30875,26 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
+"tGz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/meat{
+	anchored = 1
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/underground/enclave_base)
 "tGL" = (
 /obj/structure/falsewall/reinforced{
@@ -30962,6 +31008,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"tJo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/flour,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "tJp" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31082,38 +31133,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"tLq" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/turf/open/floor/plasteel/darkpurple/side,
-/area/f13/underground/enclave_base)
-"tLK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/freezer/meat{
-	anchored = 1
-	},
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/underground/enclave_base)
 "tMa" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/machinery/light{
@@ -31203,11 +31222,6 @@
 "tOD" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"tOE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/flour,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/underground/enclave_base)
 "tOY" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/f13{
@@ -31300,6 +31314,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"tSs" = (
+/obj/structure/closet/crate/miningcar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "tSA" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -31368,6 +31388,11 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"tUP" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "tUT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -31975,13 +32000,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
-"usA" = (
-/obj/machinery/workbench/advanced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "uty" = (
 /obj/structure/spider/stickyweb,
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
@@ -32126,20 +32144,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"uAa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/enclave_base)
 "uAc" = (
 /obj/item/candle{
 	pixel_y = 7
@@ -32293,14 +32297,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/caves)
-"uDX" = (
-/obj/item/pickaxe/drill,
-/obj/item/clothing/glasses/meson,
-/obj/item/t_scanner/adv_mining_scanner,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "uEb" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -32472,11 +32468,6 @@
 	name = "lake water"
 	},
 /area/f13/caves)
-"uMw" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "uMA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/f13/rotten,
@@ -32511,6 +32502,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"uNp" = (
+/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "uNq" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser/pistol,
@@ -32601,12 +32599,29 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/rnd)
+"uQb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/left{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "uQl" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
+"uRA" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "uRF" = (
 /obj/structure/destructible/clockwork/wall_gear{
 	pixel_x = 32
@@ -32727,15 +32742,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/botany,
 /turf/closed/wall/r_wall,
-/area/f13/underground/enclave_base)
-"uXZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
 /area/f13/underground/enclave_base)
 "uYH" = (
 /obj/structure/flora/junglebush,
@@ -32893,14 +32899,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"vcZ" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/usscientist,
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "vdE" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/tunnel,
@@ -33528,15 +33526,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"vDw" = (
-/obj/machinery/workbench,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "vEd" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/f13/oak,
@@ -33588,10 +33577,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"vFJ" = (
-/obj/structure/chair/office/light,
+"vFO" = (
+/obj/machinery/mineral/equipment_vendor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/underground/enclave_base)
 "vGb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33740,6 +33731,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"vLO" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "vLU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/examroom,
@@ -33807,6 +33807,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"vOq" = (
+/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 10
+	},
+/area/f13/underground/enclave_base)
 "vOP" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -33878,13 +33885,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
-"vRf" = (
-/obj/structure/fans/tiny,
-/obj/structure/fireaxecabinet{
-	pixel_x = 33
-	},
-/turf/closed/wall/r_wall,
-/area/f13/underground/enclave_base)
 "vSH" = (
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/outside/water,
@@ -33964,6 +33964,15 @@
 /obj/item/clothing/under/f13/bosformgold_m,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"vWb" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "vWd" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -33974,15 +33983,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"vWF" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "vWQ" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/black,
@@ -34146,24 +34146,10 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wcI" = (
-/obj/machinery/door/airlock/science/glass{
-	name = "Science";
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "wdk" = (
 /obj/structure/nest/supermutant/nightkin,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"wdD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/dark,
-/area/f13/underground/enclave_base)
 "weA" = (
 /obj/item/crowbar{
 	pixel_x = 31
@@ -34576,6 +34562,16 @@
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/leisure)
+"wsq" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "wss" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/den)
@@ -34702,6 +34698,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wwb" = (
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "wwV" = (
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
@@ -34763,6 +34762,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/den)
+"wxw" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 9
+	},
+/area/f13/underground/enclave_base)
 "wxL" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/stack/sheet/mineral/uranium,
@@ -35426,6 +35439,18 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/den)
+"wXC" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
+"wXQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "wXS" = (
 /obj/machinery/button/door{
 	id = "boscheckpoint";
@@ -35547,25 +35572,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"xcR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/machinery/light/broken{
-	pixel_x = 16
-	},
-/obj/item/reagent_containers/food/drinks/bottle/instacoffee{
-	pixel_x = -8
-	},
-/obj/item/crafting/coffee_pot{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "xcT" = (
 /obj/machinery/conveyor/auto{
 	dir = 8
@@ -35626,14 +35632,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/caves)
-"xei" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/underground/enclave_base)
 "xek" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -35922,6 +35920,10 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"xmR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/f13,
+/area/f13/underground/enclave_base)
 "xmT" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -35963,13 +35965,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
-"xoZ" = (
-/obj/structure/rack,
-/obj/item/mop/advanced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/broom,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/underground/enclave_base)
 "xpb" = (
 /obj/item/broken_bottle,
 /turf/open/floor/plating/f13/inside,
@@ -36145,6 +36140,19 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/indestructible/ground/outside/river,
 /area/f13/bunker)
+"xtM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "xuq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb,
@@ -36162,6 +36170,14 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xuS" = (
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "xvg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -36578,15 +36594,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
-"xHP" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 10
-	},
-/area/f13/underground/enclave_base)
 "xIe" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
@@ -36608,17 +36615,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"xIG" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/underground/enclave_base)
 "xIP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/vault{
@@ -36733,24 +36729,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/dorms)
-"xNN" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "xOd" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
@@ -36807,6 +36785,23 @@
 /obj/machinery/door/airlock/abandoned,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"xRg" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/machine/mechfab,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "xRm" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "headscribedorm";
@@ -36918,10 +36913,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
-"xVE" = (
-/obj/machinery/light/small,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/underground/enclave_base)
 "xVK" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/strong,
@@ -37125,6 +37116,14 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/caves)
+"ydm" = (
+/obj/structure/rack,
+/obj/item/screwdriver/power,
+/obj/item/wirecutters/power,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "yeg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -37174,11 +37173,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/den)
-"yeN" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/underground/enclave_base)
 "yeS" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -37288,13 +37282,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
-"ykq" = (
-/obj/machinery/recharge_station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/underground/enclave_base)
 "ykJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -67394,9 +67381,9 @@ vPg
 vPg
 vPg
 ycf
-jyL
+njE
 xHi
-uMw
+dNT
 ycf
 cAp
 xYB
@@ -67651,9 +67638,9 @@ vPg
 vPg
 vPg
 ycf
-yeN
+tUP
 xHi
-vcZ
+sWZ
 ycf
 xYB
 xtx
@@ -67908,7 +67895,7 @@ vPg
 vPg
 vPg
 ycf
-pgc
+ijb
 xHi
 xHi
 ycf
@@ -68167,7 +68154,7 @@ vIC
 ycf
 ycf
 ycf
-qYJ
+nqc
 ycf
 ycf
 ycf
@@ -68415,19 +68402,19 @@ ycf
 shB
 udj
 ycf
-oaJ
-laL
-xoZ
+cjc
+ydm
+dRz
 ycf
-oPs
-hAd
-hMX
+wxw
+pDZ
+vOq
 ycf
-vDw
+bHn
 xEd
-paJ
-fSX
-xHP
+ida
+rNA
+dsM
 ycf
 vPg
 vPg
@@ -68672,19 +68659,19 @@ qtE
 srb
 uiu
 ycf
-fOL
-esS
-tby
-vRf
-drx
+pWu
+dmt
+rYE
+hkF
+gYj
 scX
-mGb
+sXB
 ycf
-usA
-cVa
-nFG
-vFJ
-pnQ
+uNp
+koM
+fcS
+wXC
+sVA
 ycf
 vPg
 vPg
@@ -68931,17 +68918,17 @@ ycf
 ycf
 mvA
 ycf
-pdO
+ehe
 ycf
 wBj
-wdD
-tLq
+hPK
+qgk
 ycf
-kJj
-cVa
+fAE
+koM
 scX
 scX
-lmp
+can
 ycf
 vPg
 vPg
@@ -69189,16 +69176,16 @@ wWp
 oAW
 ugf
 uiy
-ttc
+aiL
 qQl
 scX
 bIs
 ycf
-cks
-cVa
-hmv
+fol
+koM
+ayM
 scX
-lps
+fad
 ycf
 vPg
 vPg
@@ -69451,11 +69438,11 @@ xwZ
 lDp
 bJW
 ycf
-rFu
-cVa
+ahu
+koM
 nzP
-rNi
-pik
+pYY
+jHZ
 ycf
 vPg
 vPg
@@ -69700,19 +69687,19 @@ ycf
 ycf
 ycf
 ycf
-lpc
+fQt
 tig
 tig
-piH
+mLV
 ycf
 mvA
 ycf
 ycf
-bVL
-cVa
-gty
-xNN
-pgu
+gQq
+koM
+paG
+iNw
+xuS
 ycf
 vPg
 vPg
@@ -69958,18 +69945,18 @@ sEc
 uiJ
 lzW
 hOO
-qWX
+tig
 uiy
 vKj
 iAz
 xEd
 xEd
 iAz
-cVa
-cVa
-cVa
-cVa
-cVa
+koM
+koM
+koM
+koM
+koM
 ycf
 vPg
 vPg
@@ -70215,18 +70202,18 @@ qWX
 urT
 blZ
 vIC
-uAa
+fqf
 vKj
 uiy
 vIC
 vIC
 vIC
 ycf
-nJG
-cVa
-cVa
-cVa
-cVa
+dyh
+koM
+koM
+koM
+koM
 ycf
 vPg
 vPg
@@ -70475,15 +70462,15 @@ vIC
 vKj
 vKj
 vIC
-csu
+jJm
 vGb
-fGL
+gPM
 ycf
-cVa
-cVa
-cVa
-cVa
-bAM
+koM
+koM
+koM
+koM
+uRA
 ycf
 vPg
 vPg
@@ -70736,11 +70723,11 @@ wyb
 vGb
 xRK
 ycf
-lpZ
-cVa
-cVa
-cVa
-byF
+cUR
+koM
+koM
+koM
+pOn
 ycf
 vPg
 vPg
@@ -70980,7 +70967,7 @@ pgv
 xsH
 pgv
 vIC
-eLo
+vKj
 uiy
 vKj
 uiy
@@ -70989,12 +70976,12 @@ vKj
 vKj
 vKj
 uXV
-mEY
+xtM
 vGb
 kEa
 lkf
 ycf
-wcI
+rds
 ycf
 ycf
 ycf
@@ -71245,15 +71232,15 @@ qiu
 uiy
 uiy
 uiy
-ohL
+llq
 vGb
 vGb
 kEa
 ycf
-hjo
-cVa
-dIW
-ykq
+bGZ
+koM
+wsq
+aXv
 ycf
 vPg
 vPg
@@ -71504,13 +71491,13 @@ vIC
 vIC
 vIC
 wFF
-gQi
+ppP
 kEa
 ycf
-iAM
-mrH
-cVa
-vWF
+xRg
+oMn
+koM
+vLO
 ycf
 vPg
 vPg
@@ -71756,18 +71743,18 @@ vKj
 vIC
 uCO
 ddL
-jIC
-nKQ
-sVM
+uQb
+qpg
+oAw
 dwM
 vIC
 rHS
 vIC
 ycf
-bMC
-mrH
-cVa
-kmH
+boB
+oMn
+koM
+nlo
 ycf
 vPg
 vPg
@@ -72013,18 +72000,18 @@ rDJ
 tlE
 uGQ
 ddL
-nwp
+wXQ
 ddL
 xGm
 xGm
 xHi
 ykJ
-uXZ
+pEm
 ycf
-kHo
-cVa
-cVa
-cVa
+pRK
+koM
+koM
+koM
 ycf
 vPg
 vPg
@@ -72270,17 +72257,17 @@ vKj
 vIC
 uOr
 ddL
-liY
-cPY
+ljD
+ejA
 xGm
 xNi
 ubj
 ykJ
-aMF
+lLG
 ycf
 ycf
 ycf
-dih
+soy
 ycf
 ycf
 vPg
@@ -72531,11 +72518,11 @@ sIJ
 xGm
 sIJ
 xNi
-gwZ
+siM
 xHi
-xcR
+eoU
 ycf
-lwj
+jJj
 oJE
 kAp
 ycf
@@ -72788,12 +72775,12 @@ xNi
 xNi
 xGm
 xNi
-lms
+toi
 cOT
 kPj
 ycf
-hOn
-jzW
+vFO
+lfU
 oJE
 ycf
 vPg
@@ -73044,14 +73031,14 @@ xLc
 kNa
 jxO
 xGm
-aBI
+aAL
 nzP
 nzP
 cDx
 ycf
-nkg
-jzW
-sgJ
+aAP
+lfU
+tSs
 ycf
 vPg
 vPg
@@ -73299,16 +73286,16 @@ fQt
 vIC
 xZI
 tna
-tOE
-pAk
+tJo
+fGw
 cDx
 pjs
-tLK
+tGz
 bvF
 ycf
-uDX
+eeL
 oJE
-miu
+ajp
 ycf
 aoj
 vPg
@@ -73555,16 +73542,16 @@ vKj
 vKj
 vIC
 vEI
-cLF
-bJv
+kpt
+iLe
 tna
-dlL
+ojt
 qsI
 xPO
 bbH
 ycf
 ycf
-hGR
+kXX
 ycf
 ycf
 vPg
@@ -73819,7 +73806,7 @@ ycf
 ycf
 ycf
 ycf
-arc
+wwb
 vPg
 vPg
 vPg
@@ -74840,14 +74827,14 @@ pKX
 ycf
 vbi
 vbi
-dAs
+gUE
 vbU
 vbU
 vbU
-dAs
+gUE
 ycf
-fEX
-luY
+fwh
+oMs
 ycf
 vPg
 vPg
@@ -75097,14 +75084,14 @@ sdV
 tPg
 vtR
 vtR
-dwj
-dwj
-dwj
-dwj
-dwj
+oaH
+oaH
+oaH
+oaH
+oaH
 ycf
-dLq
-cSW
+xmR
+gux
 ycf
 aoj
 vPg
@@ -75358,10 +75345,10 @@ pTM
 psv
 psv
 psv
-dwj
-qxW
-rKg
-xVE
+oaH
+cZy
+hDQ
+rFg
 ycf
 aoj
 vPg
@@ -75610,15 +75597,15 @@ ycf
 ycf
 tPC
 wuj
-tho
+vWb
 pTM
 psv
 psv
 psv
-dwj
+oaH
 ycf
-rwA
-rKg
+tzl
+hDQ
 ycf
 aoj
 vPg
@@ -75867,12 +75854,12 @@ vPg
 ycf
 tQP
 wxb
-rTb
-xIG
-oke
-xei
-qbA
-fJO
+lOM
+sKh
+iEi
+tGk
+oSR
+fix
 ycf
 ycf
 ycf

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -50,6 +50,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"acl" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "acG" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/recharger,
@@ -219,8 +224,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/dorms)
 "ahJ" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "ahZ" = (
 /obj/structure/bed,
@@ -343,8 +352,10 @@
 	},
 /area/f13/brotherhood/archives)
 "alv" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/table,
+/obj/item/flashlight/lamp/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "alP" = (
 /obj/machinery/door/airlock/grunge{
@@ -394,6 +405,12 @@
 /obj/structure/sign/poster/prewar/poster75,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
+"ane" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/underground/enclave_base)
 "anl" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosaccesscontrol";
@@ -544,6 +561,9 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood/dorms)
+"arc" = (
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "ase" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /obj/structure/rack,
@@ -734,12 +754,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/reactor)
 "axF" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/structure/table,
+/obj/item/ship_in_a_bottle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "axW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -855,8 +873,12 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
 "aBg" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "aBq" = (
 /obj/structure/sink{
@@ -880,6 +902,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"aBI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "aBN" = (
 /obj/structure/sign/painting/library_secure{
 	persistence_id = "brotherhood_secure";
@@ -1011,18 +1038,8 @@
 	},
 /area/f13/caves)
 "aEo" = (
-/obj/structure/closet/crate/footlocker,
-/obj/item/clothing/head/collectable/kitty,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/clothing/under/f13/enclave/science,
-/obj/item/storage/backpack/satchel/enclave,
-/obj/item/clothing/head/soft/f13/enclave,
-/obj/item/clothing/mask/gas/enclave,
-/obj/item/clothing/under/f13/exile/enclave,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "aFb" = (
 /obj/item/soap,
@@ -1267,6 +1284,15 @@
 	smooth = 1
 	},
 /area/f13/brotherhood/operating)
+"aMF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "aNc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1702,6 +1728,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bbH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "bbI" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -1854,11 +1888,7 @@
 	},
 /area/f13/caves)
 "beZ" = (
-/obj/structure/bed,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "bfh" = (
 /obj/structure/table/wood,
@@ -2079,6 +2109,11 @@
 /obj/machinery/chem_master/advanced,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"blZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
 "bmf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -2399,6 +2434,17 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood/f13/old,
 /area/f13/den)
+"bvF" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "bvT" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
@@ -2470,6 +2516,17 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"byF" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "byI" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt{
@@ -2522,9 +2579,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/leisure)
 "bAg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "bAm" = (
 /obj/structure/decoration/rag{
@@ -2565,6 +2623,16 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"bAM" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "bBc" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -2780,6 +2848,12 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/den)
+"bIs" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "bIt" = (
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -2820,6 +2894,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"bJv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "bJx" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -2838,6 +2917,13 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bJW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 6
+	},
+/area/f13/underground/enclave_base)
 "bKc" = (
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
@@ -2921,6 +3007,12 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
+"bMC" = (
+/obj/structure/frame/machine,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "bMH" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight,
@@ -2956,7 +3048,10 @@
 	},
 /area/f13/caves)
 "bNT" = (
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/structure/chalkboard{
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "bNV" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -3023,12 +3118,9 @@
 	},
 /area/f13/tunnel)
 "bPx" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/bed/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "bPA" = (
 /obj/structure/chair/office/dark,
@@ -3085,8 +3177,10 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/den)
 "bRN" = (
-/obj/structure/falsewall/rust,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/ussgt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "bRP" = (
 /obj/machinery/flasher/portable,
@@ -3133,8 +3227,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "bTq" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "bTA" = (
 /obj/structure/barricade/wooden,
@@ -3234,6 +3328,16 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"bVL" = (
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "bVY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -3419,14 +3523,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "cbn" = (
-/obj/structure/closet/crate/footlocker,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/storage/backpack/satchel/enclave,
-/obj/item/clothing/head/soft/f13/enclave,
-/obj/item/clothing/mask/gas/enclave,
-/obj/item/clothing/under/f13/exile/enclave,
-/obj/machinery/light,
-/turf/open/floor/carpet/green,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "cbu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3598,12 +3699,24 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/tunnel)
 "chT" = (
-/obj/machinery/vending/hydronutrients,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
+	dir = 4;
+	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "chX" = (
 /obj/structure/table,
@@ -3665,6 +3778,16 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"cks" = (
+/obj/machinery/computer/rdconsole/core/vault,
+/obj/structure/sign/poster/official/science{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "ckx" = (
 /obj/machinery/chem_dispenser/drinks{
 	dir = 4;
@@ -3940,6 +4063,11 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
+"csu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "csw" = (
 /obj/structure/rack,
 /obj/item/stack/crafting/electronicparts/five,
@@ -4017,11 +4145,9 @@
 	},
 /area/f13/bunker)
 "cuJ" = (
-/obj/item/clothing/glasses/meson,
-/obj/item/pickaxe/drill,
-/obj/item/t_scanner/adv_mining_scanner,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "cuS" = (
 /obj/structure/closet/fridge,
@@ -4091,6 +4217,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"cwH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "cwN" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -4397,6 +4528,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"cDx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/underground/enclave_base)
 "cDC" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -4437,10 +4575,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "cEq" = (
-/obj/machinery/door/airlock/survival_pod/glass{
-	req_one_access_txt = "134"
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "cFj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4652,10 +4793,13 @@
 	},
 /area/f13/bunker)
 "cLc" = (
-/obj/structure/closet/locker,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/book/granter/trait/midsurgery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/uslt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "cLd" = (
 /obj/structure/disposalpipe/trunk/multiz,
@@ -4679,6 +4823,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"cLF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "cLJ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -4774,6 +4923,13 @@
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"cOT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fireaxecabinet{
+	pixel_x = 33
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "cPg" = (
 /obj/structure/sign/poster/prewar/poster93,
 /turf/closed/wall/r_wall,
@@ -4797,6 +4953,13 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"cPY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "cQc" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -4912,6 +5075,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
+"cSw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/usspy,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "cSE" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
@@ -4946,6 +5115,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"cSW" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "cSY" = (
 /turf/open/water,
 /area/f13/caves)
@@ -5033,6 +5208,12 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"cVa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "cVg" = (
 /obj/item/chair/wood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5082,8 +5263,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "cWf" = (
-/obj/structure/closet/locker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "cWy" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -5170,10 +5354,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/den)
 "daA" = (
-/obj/machinery/door/airlock/survival_pod/glass{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "daK" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -5253,11 +5435,11 @@
 /turf/closed/wall/rust,
 /area/f13/den)
 "ddk" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "ddv" = (
 /obj/effect/decal/remains/human,
@@ -5320,6 +5502,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/archives)
+"ddL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "deM" = (
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/subway,
@@ -5418,6 +5605,13 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"dih" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Science";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "dii" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
@@ -5582,6 +5776,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
+"dlL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/freezer,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "dlU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5816,6 +6018,29 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"drx" = (
+/obj/structure/rack,
+/obj/item/stock_parts/capacitor/adv,
+/obj/item/stock_parts/capacitor/adv,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/scanning_module/adv,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/underground/enclave_base)
 "drK" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light/small/broken{
@@ -5932,6 +6157,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"dwj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "dwn" = (
 /turf/open/floor/f13{
 	dir = 8;
@@ -5953,6 +6185,11 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/caves)
+"dwM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "dxi" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustycorner"
@@ -6086,6 +6323,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"dAs" = (
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/underground/enclave_base)
 "dAI" = (
 /obj/machinery/light/fo13colored/Aqua{
 	brightness = 3;
@@ -6125,16 +6372,18 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/den)
 "dBl" = (
-/obj/machinery/plantgenes,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "dBA" = (
 /obj/item/trash/boritos,
 /turf/open/floor/plating/tunnel,
 /area/f13/den)
 "dBB" = (
-/obj/structure/chair/f13chair2,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "dBL" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -6319,6 +6568,12 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"dHh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "dHv" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -6401,11 +6656,24 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"dIW" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "dJh" = (
-/obj/item/pickaxe/drill,
-/obj/item/clothing/glasses/meson,
-/obj/item/t_scanner/adv_mining_scanner,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/structure/table,
+/obj/item/book/granter/trait/chemistry{
+	name = "Chemistry for Vault Dwellers";
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "dJm" = (
 /obj/machinery/light/small,
@@ -6458,6 +6726,10 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"dLq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/f13,
+/area/f13/underground/enclave_base)
 "dLs" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -6558,6 +6830,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/den)
+"dPd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/barrel/four,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "dPo" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/inside/subway,
@@ -6750,6 +7030,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"dUy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
 "dUO" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -6829,8 +7116,25 @@
 /turf/closed/wall/rust,
 /area/f13/caves)
 "dXH" = (
-/obj/structure/sign/poster/contraband/pinup_funk,
-/turf/closed/wall/rust,
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/stamp/captain{
+	name = "overseer's rubber stamp";
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/pen/fountain/captain{
+	desc = "It's an expensive Oak fountain pen, engraved with the numbers 113. The nib is quite sharp.";
+	name = "overseer's fountain pen";
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "dXS" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo,
@@ -7162,11 +7466,25 @@
 /obj/item/trash,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"efS" = (
-/obj/machinery/light{
-	dir = 1
+"efL" = (
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
+"efS" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/apple/gold{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "egc" = (
 /obj/structure/table/reinforced,
@@ -7624,6 +7942,14 @@
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/brotherhood/operations)
+"esS" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach{
+	faction = list("raider")
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "esX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/right{
@@ -7702,6 +8028,13 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/dorms)
+"euO" = (
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 4;
+	output_dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/underground/enclave_base)
 "euZ" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -7809,11 +8142,13 @@
 	},
 /area/f13/brotherhood/mining)
 "exD" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table,
+/obj/item/papercutter{
+	pixel_x = 3;
+	pixel_y = 11
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "exN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8073,8 +8408,9 @@
 	},
 /area/f13/bunker)
 "eFn" = (
-/obj/machinery/smartfridge/food,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "eFq" = (
 /obj/structure/rack,
@@ -8093,10 +8429,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "eFF" = (
-/obj/machinery/door/airlock/survival_pod/glass{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/bed/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "eFU" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -8286,8 +8623,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eKP" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/usspy,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "eKX" = (
 /obj/structure/table,
@@ -8311,6 +8652,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
+"eLo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "eLq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -8342,8 +8688,11 @@
 	},
 /area/f13/den)
 "eMr" = (
-/obj/structure/bed,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/ussgt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "eME" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8760,12 +9109,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "fcz" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "fcI" = (
 /obj/structure/table/wood/poker,
@@ -9396,9 +9742,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "frU" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/structure/chair/comfy/lime{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "frX" = (
 /obj/structure/wreck/trash/machinepiletwo,
@@ -9687,10 +10036,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/den)
 "fAB" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/black,
-/obj/machinery/light,
-/turf/open/floor/carpet/black,
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "fAJ" = (
 /obj/effect/turf_decal/caution/stand_clear/white{
@@ -9702,8 +10054,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "fAK" = (
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "fAR" = (
 /mob/living/simple_animal/hostile/eyebot{
@@ -9873,6 +10228,10 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
+"fEX" = (
+/obj/structure/chair/e_chair,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "fGt" = (
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/inside/subway,
@@ -9884,6 +10243,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
+"fGL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "fGW" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -9995,6 +10359,18 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"fJO" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "fJQ" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
@@ -10168,6 +10544,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
+"fOL" = (
+/obj/structure/mopbucket,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/item/caution{
+	pixel_x = -8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "fOZ" = (
 /obj/structure/simple_door/metal/iron,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -10226,6 +10616,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"fQt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "fQz" = (
 /turf/open/floor/f13{
 	dir = 8;
@@ -10335,10 +10730,17 @@
 	},
 /area/f13/bunker)
 "fSW" = (
-/obj/machinery/light{
+/obj/structure/chair/f13foldupchair{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/underground/enclave_base)
+"fSX" = (
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
 /area/f13/underground/enclave_base)
 "fTe" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -10524,7 +10926,14 @@
 	},
 /area/f13/brotherhood/dorms)
 "fYg" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "fYj" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -10586,15 +10995,11 @@
 /area/f13/bunker)
 "gaw" = (
 /obj/structure/closet/crate/footlocker,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/storage/backpack/satchel/enclave,
-/obj/item/clothing/head/soft/f13/enclave,
-/obj/item/clothing/mask/gas/enclave,
-/obj/item/clothing/under/f13/exile/enclave,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/item/clothing/under/f13/enclave/officer,
+/obj/item/clothing/head/helmet/f13/helmet/enclave/officer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "gaI" = (
 /obj/structure/table,
@@ -10717,6 +11122,12 @@
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
+"gey" = (
+/obj/structure/bed/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "geH" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/structure/fence/handrail{
@@ -10906,13 +11317,10 @@
 	},
 /area/f13/caves)
 "gmm" = (
-/obj/structure/closet/crate/footlocker,
-/obj/item/clothing/shoes/f13/enclave/serviceboots,
-/obj/item/storage/backpack/satchel/enclave,
-/obj/item/clothing/head/soft/f13/enclave,
-/obj/item/clothing/mask/gas/enclave,
-/obj/item/clothing/under/f13/exile/enclave,
-/turf/open/floor/carpet/green,
+/obj/item/bedsheet/captain,
+/obj/structure/bed/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "gmo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11007,6 +11415,17 @@
 /obj/structure/barricade/bars,
 /turf/open/water,
 /area/f13/tunnel)
+"goc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "gol" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -11165,6 +11584,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"gty" = (
+/obj/machinery/rnd/server/vault,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "gtS" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
@@ -11261,6 +11687,11 @@
 	},
 /turf/open/water,
 /area/f13/brotherhood/rnd)
+"gwZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "gxd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11281,8 +11712,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "gxY" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/underground/enclave_base)
 "gyf" = (
 /obj/structure/ore_box,
@@ -11628,10 +12060,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gGZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 1
+	dir = 4;
+	pixel_y = -16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/landmark/start/f13/usspy,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "gHh" = (
 /obj/machinery/light/broken{
@@ -11683,6 +12119,14 @@
 	},
 /turf/closed/wall,
 /area/f13/tcoms)
+"gIl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "gIt" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -12008,6 +12452,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"gQi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "gQx" = (
 /obj/machinery/button/door{
 	id = "boscheckpoint";
@@ -12368,6 +12819,12 @@
 /obj/structure/fluff/rails,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"haO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/obj/structure/curtain,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/underground/enclave_base)
 "haS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/smes/engineering,
@@ -12509,6 +12966,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"hjo" = (
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "hjD" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13{
@@ -12590,6 +13053,14 @@
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
+"hmv" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/aug_manipulator,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "hmM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightlifter,
@@ -12827,8 +13298,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "huo" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/decoration/smokeold{
+	pixel_x = 32
+	},
+/turf/closed/wall/r_wall,
 /area/f13/underground/enclave_base)
 "huS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -12848,11 +13321,11 @@
 	},
 /area/f13/brotherhood/operations)
 "hvx" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain{
+	color = "red"
 	},
-/turf/open/floor/plasteel/darkblue/corner,
+/turf/open/floor/plating/f13,
 /area/f13/underground/enclave_base)
 "hvO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12877,9 +13350,20 @@
 /turf/open/water,
 /area/f13/brotherhood/rnd)
 "hwD" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "hwF" = (
 /obj/structure/disposalpipe/junction/flip,
@@ -12934,6 +13418,12 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
+"hAd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/underground/enclave_base)
 "hAl" = (
 /obj/structure/destructible/clockwork/wall_gear,
 /obj/machinery/light/floor,
@@ -12969,6 +13459,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"hCy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "hCA" = (
 /obj/machinery/button/door{
 	id = "okay";
@@ -13059,6 +13561,13 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"hGR" = (
+/obj/machinery/door/airlock/vault{
+	req_one_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "hHs" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -13235,6 +13744,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"hMX" = (
+/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 10
+	},
+/area/f13/underground/enclave_base)
 "hNk" = (
 /obj/machinery/light/small,
 /obj/structure/curtain{
@@ -13279,6 +13795,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
+"hOn" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "hOr" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -13308,6 +13831,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"hOO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "hOP" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
@@ -13842,9 +14370,9 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
 "ihM" = (
-/obj/structure/table,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "iiu" = (
 /obj/structure/grille,
@@ -13886,7 +14414,11 @@
 	},
 /area/f13/tunnel)
 "ijv" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "ijW" = (
 /obj/item/trash/f13/tin,
@@ -13917,8 +14449,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ikY" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "imd" = (
 /obj/item/circular_saw,
@@ -14192,8 +14727,9 @@
 /area/f13/caves)
 "iwr" = (
 /obj/structure/rack,
-/obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "iwP" = (
 /obj/structure/table,
@@ -14296,6 +14832,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"iAz" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "iAL" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -14304,6 +14848,23 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"iAM" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/machine/mechfab,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "iAR" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
@@ -14404,6 +14965,12 @@
 /obj/effect/decal/cleanable/blood/gibs/human,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"iFS" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "iGd" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14548,6 +15115,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
+"iOd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/underground/enclave_base)
 "iOt" = (
 /obj/structure/rack,
 /obj/item/melee/classic_baton/telescopic{
@@ -14625,10 +15197,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPU" = (
-/obj/machinery/door/airlock/survival_pod/glass{
-	req_one_access_txt = "134"
+/obj/structure/chair/f13foldupchair{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "iQt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14748,8 +15325,15 @@
 	},
 /area/f13/den)
 "iUQ" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/underground/enclave_base)
 "iUY" = (
 /obj/machinery/vending/cigarette,
@@ -14818,8 +15402,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iWI" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "iWR" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15010,6 +15595,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"jek" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "jep" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
@@ -15081,6 +15672,15 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"jfH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
 "jfS" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -15292,6 +15892,13 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/den)
+"joD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "joN" = (
 /obj/structure/easel,
 /turf/open/floor/carpet,
@@ -15579,6 +16186,16 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"jxO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/reagent_containers/food/condiment/ketchup{
+	pixel_x = -2;
+	pixel_y = 15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "jxS" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13{
@@ -15587,16 +16204,26 @@
 	},
 /area/f13/den)
 "jxZ" = (
-/obj/structure/sign/poster/contraband/pinup_ride,
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "surfacevaultelevatorladder";
+	name = "maintenance ladder"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/underground/enclave_base)
 "jyi" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/carpet/blue,
 /area/f13/followers)
 "jyB" = (
-/obj/machinery/door/unpowered/celldoor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "jyH" = (
 /obj/structure/lattice{
@@ -15609,6 +16236,14 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/archives)
+"jyL" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "jyQ" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -15631,6 +16266,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
+"jzW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "jAd" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15820,6 +16461,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
+"jIC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/left{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "jJe" = (
 /obj/structure/window/reinforced/spawner/north{
 	dir = 8
@@ -16497,12 +17145,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "khf" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/obj/effect/landmark/start/f13/usspy,
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "khz" = (
 /obj/effect/decal/waste{
@@ -16559,6 +17202,12 @@
 "kiM" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"kiO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/defibrillator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
 "kiV" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16623,6 +17272,13 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"kmH" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "kmM" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -16921,12 +17577,21 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "kzg" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "kzG" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/underground/enclave_base)
 "kzL" = (
 /obj/machinery/button/crematorium{
@@ -16951,6 +17616,10 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"kAp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "kAv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -17059,6 +17728,11 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"kEa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "kEu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shovel/spade,
@@ -17133,6 +17807,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"kHo" = (
+/obj/machinery/vending/robotics,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "kHD" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -17171,6 +17851,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"kJj" = (
+/obj/machinery/rnd/production/protolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "kJq" = (
 /obj/structure/bed,
 /obj/structure/spider/stickyweb,
@@ -17278,6 +17965,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"kNa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "kNb" = (
 /obj/structure/simple_door/bunker{
 	name = "Locker Room"
@@ -17321,18 +18020,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operating)
+"kPj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "kPB" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/rat,
 /turf/open/floor/f13/wood,
 /area/f13/den)
 "kPQ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/machinery/autolathe/constructionlathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "kQs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17341,12 +18042,12 @@
 	},
 /area/f13/brotherhood/mining)
 "kQv" = (
-/obj/machinery/processor,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17483,16 +18184,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "kVA" = (
-/obj/structure/table,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/item/radio/headset/headset_enclave,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "kVP" = (
 /obj/structure/filingcabinet,
@@ -17525,9 +18222,11 @@
 /area/f13/brotherhood/leisure)
 "kXI" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "kYT" = (
 /obj/structure/simple_door/bunker,
@@ -17547,6 +18246,14 @@
 "kZZ" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood/mining)
+"laL" = (
+/obj/structure/rack,
+/obj/item/screwdriver/power,
+/obj/item/wirecutters/power,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "laN" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -17573,8 +18280,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lbx" = (
-/obj/structure/sign/poster/contraband/free_tonto,
-/turf/closed/wall/rust,
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood,
 /area/f13/underground/enclave_base)
 "lbB" = (
 /obj/structure/chair/bench,
@@ -17827,6 +18536,13 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"liY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "ljc" = (
 /obj/item/flag/bos,
 /obj/machinery/light{
@@ -17861,8 +18577,10 @@
 	},
 /area/f13/brotherhood/operating)
 "lkf" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/fireaxecabinet{
+	pixel_x = 33
+	},
+/turf/closed/wall/r_wall,
 /area/f13/underground/enclave_base)
 "lkl" = (
 /obj/structure/bonfire/prelit,
@@ -17929,6 +18647,28 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"lmp" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
+"lms" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 9;
+	pixel_y = 19
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "lmB" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/decoration/rag,
@@ -17957,6 +18697,11 @@
 "lnr" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"lnZ" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "lof" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken,
@@ -17980,6 +18725,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lpc" = (
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "lph" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -18002,6 +18755,29 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
+"lps" = (
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "lpI" = (
 /obj/item/storage/trash_stack,
 /obj/structure/destructible/tribal_torch/lit,
@@ -18022,6 +18798,15 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"lpZ" = (
+/obj/structure/showcase/horrific_experiment{
+	icon_state = "pod_1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "lqf" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/ruins,
@@ -18038,13 +18823,9 @@
 	},
 /area/f13/bunker)
 "lqA" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "lqI" = (
 /obj/structure/table,
@@ -18163,6 +18944,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"luY" = (
+/obj/item/soap,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "lvc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -18189,6 +18975,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
+"lwj" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "lwv" = (
 /obj/structure/table/wood/settler,
 /obj/item/gun/ballistic/revolver/caravan_shotgun,
@@ -18271,6 +19063,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"lzW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/mask/gas/enclave,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
 "lAv" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -18348,7 +19148,8 @@
 /turf/open/water,
 /area/f13/tunnel)
 "lCw" = (
-/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "lCx" = (
@@ -18378,6 +19179,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"lDp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 4
+	},
+/area/f13/underground/enclave_base)
 "lDx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -18404,6 +19216,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"lEC" = (
+/obj/structure/closet/crate/footlocker,
+/obj/item/clothing/shoes/f13/enclave/serviceboots,
+/obj/item/storage/backpack/satchel/enclave,
+/obj/item/clothing/head/soft/f13/enclave,
+/obj/item/clothing/mask/gas/enclave,
+/obj/item/clothing/under/f13/exile/enclave,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "lEF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -18692,8 +19514,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "lQf" = (
-/obj/structure/closet/crate/miningcar,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath,
+/obj/item/storage/box/gloves,
+/obj/item/roller,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "lQz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18886,8 +19714,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "lZY" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/underground/enclave_base)
 "maq" = (
 /obj/structure/cable{
@@ -18996,8 +19825,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "mgD" = (
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
+"mgX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge/abandoned{
+	name = "lieutenant's office";
+	req_one_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/underground/enclave_base)
 "mhs" = (
 /obj/structure/chair/bench,
@@ -19007,6 +19847,14 @@
 "mir" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"miu" = (
+/obj/item/clothing/glasses/meson,
+/obj/item/pickaxe/drill,
+/obj/item/t_scanner/adv_mining_scanner,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "miI" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -19096,8 +19944,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "mlV" = (
-/obj/structure/sign/poster/contraband/buzzfuzz,
-/turf/closed/wall/rust,
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "mmb" = (
 /obj/effect/decal/fakelattice,
@@ -19150,10 +19999,11 @@
 	},
 /area/f13/clinic)
 "mno" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/mre,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "mnG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19257,8 +20107,19 @@
 	},
 /area/f13/clinic)
 "mrp" = (
-/obj/structure/sign/poster/contraband/eat,
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
+"mrH" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/underground/enclave_base)
 "msn" = (
 /obj/machinery/light{
@@ -19291,8 +20152,9 @@
 	},
 /area/f13/brotherhood/offices1st)
 "mth" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/underground/enclave_base)
 "mtw" = (
 /obj/structure/closet/crate/bin,
@@ -19333,7 +20195,26 @@
 	},
 /area/f13/bunker)
 "muV" = (
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/ranged{
+	pixel_x = -30;
+	spawn_time = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
+"mvg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/clothing/mask/surgical{
+	pixel_y = -4
+	},
+/obj/item/healthanalyzer/advanced,
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "mvl" = (
 /obj/machinery/light/fo13colored{
@@ -19350,6 +20231,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/den)
+"mvA" = (
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "mvH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -19497,6 +20382,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"mCm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fireaxecabinet{
+	pixel_x = 33
+	},
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "mCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -19551,6 +20443,19 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tcoms)
+"mEY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "mFz" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -19573,6 +20478,11 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/armory)
+"mGb" = (
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "mGK" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -20617,8 +21527,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "nfz" = (
-/obj/machinery/computer/rdconsole,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "nfB" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -20744,6 +21655,16 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"nkg" = (
+/obj/structure/ore_box,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "nkh" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small{
@@ -21051,6 +21972,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"nwp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "nwA" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -21140,6 +22068,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/den)
+"nzP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/underground/enclave_base)
 "nAd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
@@ -21263,8 +22197,10 @@
 	},
 /area/f13/den)
 "nFh" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "nFk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21291,6 +22227,13 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"nFG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "nFJ" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -21316,8 +22259,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/den)
 "nGf" = (
-/obj/structure/sign/poster/contraband/pinup_couch,
-/turf/closed/wall/rust,
+/obj/structure/rack,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "nGm" = (
 /obj/structure/barricade/wooden,
@@ -21328,9 +22274,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "nGx" = (
-/obj/structure/table/optable,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "nGD" = (
 /obj/item/chair/stool/retro/black,
@@ -21442,12 +22390,29 @@
 /obj/item/seeds/cannabis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
+"nJG" = (
+/obj/structure/showcase/horrific_experiment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "nJT" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
+"nKQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "nKZ" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
@@ -21632,8 +22597,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "nQc" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
 "nQe" = (
 /obj/structure/table,
@@ -21946,6 +22917,13 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"oaJ" = (
+/obj/structure/rack,
+/obj/item/storage/belt,
+/obj/item/storage/belt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "oaP" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -21969,6 +22947,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"obK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "obV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -22193,6 +23176,11 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/den)
+"ohL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "ohO" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -22273,10 +23261,26 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"oka" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "okd" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"oke" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "okm" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkrustysolid"
@@ -22424,16 +23428,27 @@
 	},
 /area/f13/tunnel)
 "opM" = (
-/turf/closed/mineral/random/high_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/underground/enclave_base)
 "oqd" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/underground/enclave_base)
 "oqJ" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/reagent_containers/food/snacks/burger/bigbite,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "vaultelevator";
+	name = "Blast Door Exit";
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "oqV" = (
 /obj/machinery/light/small{
@@ -22513,6 +23528,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
+"otr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "ouz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22670,8 +23690,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "oAo" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
+"oAW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "oBl" = (
 /obj/machinery/microwave,
@@ -22763,10 +23789,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "oEB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "oEC" = (
 /obj/structure/showcase/horrific_experiment,
@@ -22898,6 +23923,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"oJE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "oJF" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -22952,10 +23982,9 @@
 	},
 /area/f13/caves)
 "oNq" = (
-/obj/machinery/door/airlock/survival_pod/glass{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/underground/enclave_base)
 "oNs" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -23005,6 +24034,20 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
+"oPs" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 9
+	},
+/area/f13/underground/enclave_base)
 "oPz" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -23056,6 +24099,12 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"oQt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs{
+	icon = 'icons/obj/stairs.dmi'
+	},
+/area/f13/underground/enclave_base)
 "oQA" = (
 /obj/machinery/button/door{
 	id = "sentdorm";
@@ -23312,6 +24361,15 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
+"paJ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chalkboard,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/underground/enclave_base)
 "paO" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
@@ -23367,9 +24425,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
+"pdO" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/underground/enclave_base)
 "pec" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/chemistry,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/underground/enclave_base)
 "pez" = (
 /obj/machinery/light/small{
@@ -23433,16 +24499,39 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
+"pgc" = (
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "pgt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"pgu" = (
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
+"pgv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "pgw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"phn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "phA" = (
 /obj/item/instrument/accordion,
 /obj/structure/rack,
@@ -23461,12 +24550,21 @@
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"pik" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "pis" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"piH" = (
+/obj/structure/sign/departments/science,
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "piI" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -23484,6 +24582,14 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"pjs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "pjR" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -23509,6 +24615,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"plc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/firstaid,
+/obj/item/storage/firstaid{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "pld" = (
 /obj/structure/sink{
 	dir = 8;
@@ -23539,9 +24655,14 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "pmR" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "134"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/underground/enclave_base)
 "pmV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23550,6 +24671,12 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"pnQ" = (
+/obj/structure/table,
+/obj/item/integrated_circuit_printer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
 "pnV" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -23644,10 +24771,9 @@
 	},
 /area/f13/clinic)
 "psv" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/underground/enclave_base)
 "psA" = (
 /obj/structure/table/wood,
@@ -23865,6 +24991,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"pAk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "pAn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -24166,7 +25297,13 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "pKX" = (
-/turf/closed/indestructible/f13/matrix,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/underground/enclave_base)
 "pLl" = (
 /obj/structure/window/fulltile/store,
@@ -24185,6 +25322,14 @@
 	icon_state = "engine"
 	},
 /area/f13/brotherhood/mining)
+"pLH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/machinery/door/poddoor{
+	id = "vaultelevator"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "pMg" = (
 /obj/item/stack/ore/blackpowder/two,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24455,8 +25600,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "pTM" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/underground/enclave_base)
 "pUe" = (
 /obj/machinery/door/airlock/medical{
@@ -24665,6 +25810,15 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"qbA" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "qbH" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -24884,6 +26038,13 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
+"qiu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "qiH" = (
 /obj/item/trash/f13/fancylads,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25246,6 +26407,12 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"qst" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "qsy" = (
 /mob/living/simple_animal/hostile/chinese{
 	name = "Comrade Xiaojian"
@@ -25254,6 +26421,15 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/caves)
+"qsI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "qsM" = (
 /obj/structure/decoration/smokeold{
 	pixel_y = -31
@@ -25293,12 +26469,8 @@
 	},
 /area/f13/clinic)
 "qtE" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
+/obj/structure/mirror,
+/turf/closed/wall/r_wall,
 /area/f13/underground/enclave_base)
 "qtL" = (
 /turf/open/space/basic,
@@ -25356,6 +26528,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"qwT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs{
+	icon = 'icons/obj/stairs.dmi'
+	},
+/area/f13/underground/enclave_base)
 "qwV" = (
 /obj/item/clothing/under/f13/bosformsilver_m,
 /obj/item/clothing/shoes/laceup,
@@ -25404,6 +26583,10 @@
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"qxW" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/underground/enclave_base)
 "qya" = (
 /obj/structure/table{
 	layer = 2.9
@@ -25436,9 +26619,10 @@
 	},
 /area/f13/brotherhood/offices1st)
 "qyz" = (
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_master/advanced,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "qyH" = (
 /obj/structure/rack/shelf_metal,
@@ -25959,12 +27143,20 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/den)
+"qQl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/underground/enclave_base)
 "qQw" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "qQz" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -26206,8 +27398,8 @@
 	},
 /area/f13/bunker)
 "qWX" = (
-/obj/structure/closet/fridge/meat,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "qXf" = (
 /obj/structure/chair/bench,
@@ -26267,6 +27459,12 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
+"qYJ" = (
+/obj/machinery/door/airlock/wood{
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "qYM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -26597,6 +27795,15 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
+"rpE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/usscientist,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "rpH" = (
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel{
@@ -26764,6 +27971,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
+"rwA" = (
+/obj/structure/closet,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "rwE" = (
 /obj/structure/table/wood,
 /obj/structure/spider/stickyweb,
@@ -27022,8 +28233,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "rDJ" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "rDM" = (
 /obj/structure/debris/v2,
@@ -27095,6 +28307,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
+"rFu" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "rFB" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/f13/wood,
@@ -27116,6 +28340,11 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"rFU" = (
+/obj/structure/bed/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "rGe" = (
 /turf/open/floor/f13/wood,
 /area/f13/den)
@@ -27145,6 +28374,11 @@
 	icon_state = "engine"
 	},
 /area/f13/brotherhood/mining)
+"rHS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "rId" = (
 /obj/structure/disposalpipe/broken,
 /turf/open/water,
@@ -27195,6 +28429,9 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"rKg" = (
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "rKy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27290,6 +28527,11 @@
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
 /area/f13/caves)
+"rNi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "rNk" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light/small{
@@ -27299,6 +28541,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
+"rNz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "rNO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -27512,6 +28761,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
+"rTb" = (
+/obj/item/paper/crumpled/ruins,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "rTg" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/plating/tunnel{
@@ -27578,6 +28837,15 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"rXm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/book/granter/trait/lowsurgery,
+/obj/item/clipboard{
+	pixel_x = 36
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
 "rXA" = (
 /obj/item/instrument/eguitar,
 /obj/structure/rack,
@@ -27668,7 +28936,12 @@
 	},
 /area/f13/tunnel)
 "saS" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/underground/enclave_base)
 "saX" = (
 /obj/structure/table,
@@ -27695,6 +28968,10 @@
 /obj/item/flashlight/lamp,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"scX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "sdf" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/fakelattice,
@@ -27706,7 +28983,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "sdV" = (
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/underground/enclave_base)
 "seg" = (
 /obj/structure/window/reinforced/spawner{
@@ -27796,6 +29075,12 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"sgJ" = (
+/obj/structure/closet/crate/miningcar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "sgN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27820,11 +29105,15 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "shB" = (
-/obj/structure/ore_box,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/underground/enclave_base)
 "shM" = (
 /obj/structure/table,
@@ -27956,6 +29245,12 @@
 "snm" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
+"snF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
 "snH" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -28010,8 +29305,13 @@
 /turf/open/indestructible/ground/outside/river,
 /area/f13/bunker)
 "srb" = (
-/obj/structure/bed/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/razor,
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/underground/enclave_base)
 "srD" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -28289,8 +29589,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/leisure)
 "sEc" = (
-/obj/effect/landmark/start/f13/usscientist,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "sEn" = (
 /obj/structure/ladder/unbreakable{
@@ -28362,6 +29663,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+"sIJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "sJm" = (
 /obj/structure/table/wood/bar,
 /obj/item/clothing/head/welding/weldingfire,
@@ -28619,8 +29925,10 @@
 	},
 /area/f13/brotherhood/operations)
 "sUH" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "sUK" = (
 /turf/open/floor/f13{
@@ -28645,6 +29953,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"sVM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/nest/raider/ranged{
+	pixel_x = -30;
+	spawn_time = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "sVP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28696,6 +30013,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
+"sZq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/underground/enclave_base)
 "sZW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28736,6 +30057,10 @@
 "tbu" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/caves)
+"tby" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "tbE" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/mprostitute,
@@ -28849,6 +30174,15 @@
 /obj/item/clothing/head/bio_hood/f13/hazmat,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
+"tho" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "thC" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/hydroponics/constructable,
@@ -28888,6 +30222,9 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"tig" = (
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "tiF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -28942,9 +30279,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tlE" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/mre,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster72,
+/turf/closed/wall/r_wall,
 /area/f13/underground/enclave_base)
 "tlS" = (
 /obj/structure/table/wood/settler,
@@ -29010,6 +30347,10 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tna" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "tni" = (
 /obj/structure/lattice{
 	density = 1
@@ -29165,6 +30506,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"ttc" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Science";
+	req_access_txt = "134"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/underground/enclave_base)
 "tte" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -29350,8 +30700,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "tBx" = (
-/obj/structure/sign/poster/contraband/fun_police,
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/r_wall,
 /area/f13/underground/enclave_base)
 "tBM" = (
 /obj/structure/chair/wood/normal{
@@ -29490,7 +30846,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "tGx" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "tGL" = (
 /obj/structure/falsewall/reinforced{
@@ -29724,6 +31082,38 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"tLq" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/underground/enclave_base)
+"tLK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/meat{
+	anchored = 1
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "tMa" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/machinery/light{
@@ -29802,9 +31192,22 @@
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"tOC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "tOD" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"tOE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/flour,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "tOY" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/f13{
@@ -29812,19 +31215,25 @@
 	},
 /area/f13/bunker)
 "tPg" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
 /area/f13/underground/enclave_base)
 "tPl" = (
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "tPC" = (
-/obj/structure/table,
-/obj/item/storage/box/disks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/restraints/legcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
 /area/f13/underground/enclave_base)
 "tQm" = (
 /obj/structure/window/reinforced/spawner,
@@ -29847,11 +31256,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/rnd)
 "tQP" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
+"tRc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/table/optable/abductor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "tRl" = (
 /obj/structure/lattice{
@@ -30160,6 +31579,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"ubj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "ubt" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/subway,
@@ -30169,9 +31594,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "udj" = (
-/obj/structure/bed,
-/obj/machinery/light,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/decoration/vent,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/underground/enclave_base)
 "uel" = (
 /obj/structure/simple_door/metal/barred,
@@ -30214,6 +31648,10 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
+"ugf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/underground/enclave_base)
 "ugq" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -30279,19 +31717,22 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/tunnel)
 "uiu" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/reagent_containers/food/snacks/fries,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
+"uiy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "uiJ" = (
-/obj/structure/closet/crate/footlocker,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/item/clothing/under/f13/enclave/officer,
-/obj/item/clothing/head/helmet/f13/helmet/enclave/officer,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_heater,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "uiY" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -30530,14 +31971,16 @@
 	},
 /area/f13/tunnel)
 "urT" = (
-/obj/structure/closet/locker,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/shoes/sneakers/black,
-/obj/item/clothing/shoes/sneakers/black,
-/obj/item/clothing/shoes/sneakers/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/underground/enclave_base)
+"usA" = (
+/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/underground/enclave_base)
 "uty" = (
 /obj/structure/spider/stickyweb,
@@ -30638,10 +32081,10 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/leisure)
 "uxZ" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "uyl" = (
 /obj/structure/sink{
@@ -30683,6 +32126,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
+"uAa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "uAc" = (
 /obj/item/candle{
 	pixel_y = 7
@@ -30800,10 +32257,10 @@
 	},
 /area/f13/tunnel)
 "uCO" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "134"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/right,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/underground/enclave_base)
 "uCP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30822,6 +32279,13 @@
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
+"uDu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "uDO" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -30829,6 +32293,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/caves)
+"uDX" = (
+/obj/item/pickaxe/drill,
+/obj/item/clothing/glasses/meson,
+/obj/item/t_scanner/adv_mining_scanner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "uEb" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -30872,17 +32344,12 @@
 	},
 /area/f13/tunnel)
 "uGQ" = (
-/obj/structure/closet/locker,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/black,
-/obj/item/clothing/shoes/sneakers/black,
-/obj/item/clothing/shoes/sneakers/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/middle,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/underground/enclave_base)
 "uHt" = (
 /obj/effect/decal/waste{
@@ -31005,6 +32472,11 @@
 	name = "lake water"
 	},
 /area/f13/caves)
+"uMw" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "uMA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/f13/rotten,
@@ -31062,8 +32534,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "uOr" = (
-/obj/structure/sign/poster/contraband/have_a_puff,
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/left,
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/underground/enclave_base)
 "uOL" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
@@ -31166,7 +32645,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "uSO" = (
-/turf/open/floor/carpet/green,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/underground/enclave_base)
 "uSQ" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -31239,6 +32723,20 @@
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/carpet,
 /area/f13/followers)
+"uXV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/botany,
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
+"uXZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "uYH" = (
 /obj/structure/flora/junglebush,
 /obj/structure/bus_door,
@@ -31320,8 +32818,11 @@
 	},
 /area/f13/bunker)
 "vbi" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/underground/enclave_base)
 "vbx" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -31332,6 +32833,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/den)
+"vbU" = (
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/underground/enclave_base)
 "vbV" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -31384,6 +32893,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"vcZ" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/usscientist,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "vdE" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/tunnel,
@@ -31782,10 +33299,10 @@
 	},
 /area/f13/bunker)
 "vtR" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
 /area/f13/underground/enclave_base)
 "vuv" = (
 /obj/item/electronic_assembly/drone/medbot,
@@ -31940,6 +33457,9 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"vyR" = (
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/underground/enclave_base)
 "vzw" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
@@ -31950,10 +33470,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
 "vzF" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/underground/enclave_base)
 "vzK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32008,6 +33528,15 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"vDw" = (
+/obj/machinery/workbench,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "vEd" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/f13/oak,
@@ -32019,6 +33548,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"vEI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/microwave/stove,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/underground/enclave_base)
 "vFi" = (
 /obj/structure/table{
 	layer = 2.9
@@ -32053,6 +33588,15 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"vFJ" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
+"vGb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "vHn" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -32108,6 +33652,10 @@
 	icon_state = "grass2"
 	},
 /area/f13/clinic)
+"vIC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "vID" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -32167,6 +33715,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"vKj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/underground/enclave_base)
 "vLv" = (
 /obj/structure/lattice{
 	layer = 3
@@ -32188,6 +33740,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"vLU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/examroom,
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "vMm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
@@ -32321,6 +33878,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
+"vRf" = (
+/obj/structure/fans/tiny,
+/obj/structure/fireaxecabinet{
+	pixel_x = 33
+	},
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "vSH" = (
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/outside/water,
@@ -32410,6 +33974,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"vWF" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "vWQ" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/black,
@@ -32573,10 +34146,24 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wcI" = (
+/obj/machinery/door/airlock/science/glass{
+	name = "Science";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "wdk" = (
 /obj/structure/nest/supermutant/nightkin,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"wdD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/enclave_base)
 "weA" = (
 /obj/item/crowbar{
 	pixel_x = 31
@@ -33025,8 +34612,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "wuj" = (
-/obj/effect/landmark/start/f13/ussgt,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/underground/enclave_base)
 "wut" = (
 /obj/structure/nest/supermutant/melee{
@@ -33140,8 +34730,24 @@
 	},
 /area/f13/tunnel)
 "wxb" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/machinery/computer/terminal{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
 /area/f13/underground/enclave_base)
 "wxj" = (
 /obj/structure/fence/handrail{
@@ -33162,6 +34768,11 @@
 /obj/item/stack/sheet/mineral/uranium,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"wyb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "wyB" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -33245,6 +34856,16 @@
 "wAO" = (
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
+"wBj" = (
+/obj/structure/rack,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/assembly/timer,
+/obj/item/mining_scanner,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/underground/enclave_base)
 "wBF" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile/house{
@@ -33335,6 +34956,20 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"wFF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "wFL" = (
 /obj/structure/chair{
 	dir = 8
@@ -33728,6 +35363,15 @@
 "wUF" = (
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/brotherhood/mining)
+"wUJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	layer = 4.1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/underground/enclave_base)
 "wVy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -33752,8 +35396,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wWp" = (
-/obj/effect/landmark/start/f13/uslt,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/underground/enclave_base)
 "wWB" = (
 /obj/structure/handrail/g_central{
@@ -33900,6 +35547,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"xcR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/machinery/light/broken{
+	pixel_x = 16
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee{
+	pixel_x = -8
+	},
+/obj/item/crafting/coffee_pot{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "xcT" = (
 /obj/machinery/conveyor/auto{
 	dir = 8
@@ -33960,6 +35626,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/caves)
+"xei" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "xek" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -34289,6 +35963,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"xoZ" = (
+/obj/structure/rack,
+/obj/item/mop/advanced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/broom,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/underground/enclave_base)
 "xpb" = (
 /obj/item/broken_bottle,
 /turf/open/floor/plating/f13/inside,
@@ -34408,6 +36089,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/bronze,
 /area/f13/brotherhood/rnd)
+"xsH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/underground/enclave_base)
 "xsL" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/rag,
@@ -34539,6 +36224,12 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"xwZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 5
+	},
+/area/f13/underground/enclave_base)
 "xxk" = (
 /obj/structure/fans/tiny{
 	pixel_y = -33
@@ -34647,8 +36338,8 @@
 	},
 /area/f13/bunker)
 "xzi" = (
-/obj/structure/sign/poster/contraband/communist_state,
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/underground/enclave_base)
 "xzj" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -34812,14 +36503,23 @@
 	},
 /area/f13/caves)
 "xDt" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/item/book/granter/trait/chemistry,
+/obj/item/reagent_containers/dropper,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/underground/enclave_base)
 "xEb" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"xEd" = (
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "xFz" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/indestructible/vaultdoor,
@@ -34836,6 +36536,10 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"xGm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "xGB" = (
 /turf/open/floor/f13{
 	icon_state = "redmark"
@@ -34854,6 +36558,10 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"xHi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "xHq" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -34870,6 +36578,15 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"xHP" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 10
+	},
+/area/f13/underground/enclave_base)
 "xIe" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
@@ -34891,6 +36608,17 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"xIG" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/underground/enclave_base)
 "xIP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/vault{
@@ -34934,9 +36662,18 @@
 	},
 /area/f13/bunker)
 "xLc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/pizzabox/meat,
+/obj/item/reagent_containers/glass/rag{
+	pixel_y = 8
+	},
+/obj/structure/sign/plaques/kiddie{
+	desc = "A faded sign listing all the less-than-healthy fast foods that were sold here before the war";
+	name = "fast food menu";
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/underground/enclave_base)
 "xLe" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -34968,6 +36705,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/caves)
+"xNi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/retro,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/underground/enclave_base)
 "xNs" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -34991,6 +36733,24 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/dorms)
+"xNN" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
 "xOd" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
@@ -35014,6 +36774,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/archives)
+"xPO" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/underground/enclave_base)
 "xQo" = (
 /obj/structure/bookcase/manuals/engineering{
 	desc = "A collection of scrolls, archives and relics.";
@@ -35045,6 +36815,14 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
+"xRK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/seed_extractor,
+/obj/machinery/light/broken{
+	pixel_x = 16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/underground/enclave_base)
 "xRW" = (
 /obj/structure/simple_door/bunker/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -35140,6 +36918,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
+"xVE" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/underground/enclave_base)
 "xVK" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/strong,
@@ -35272,8 +37054,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "xZI" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/underground/enclave_base)
 "yaU" = (
 /obj/effect/decal/fakelattice,
@@ -35318,6 +37105,9 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"ycf" = (
+/turf/closed/wall/r_wall,
+/area/f13/underground/enclave_base)
 "yck" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -35384,6 +37174,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/den)
+"yeN" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "yeS" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -35493,6 +37288,18 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"ykq" = (
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/underground/enclave_base)
+"ykJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/f13/underground/enclave_base)
 "ylk" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -65329,11 +67136,11 @@ tur
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-eLE
+ycf
+ycf
+ycf
+ycf
+ycf
 cSY
 cSY
 khT
@@ -65564,6 +67371,15 @@ dXE
 vPg
 vPg
 vPg
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
 vPg
 vPg
 vPg
@@ -65577,20 +67393,11 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-eLE
+ycf
+jyL
+xHi
+uMw
+ycf
 cAp
 xYB
 xYB
@@ -65821,6 +67628,15 @@ vPg
 vPg
 vPg
 vPg
+ycf
+beZ
+beZ
+beZ
+fAB
+fAK
+iPU
+beZ
+ycf
 vPg
 vPg
 vPg
@@ -65834,20 +67650,11 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-eLE
+ycf
+yeN
+xHi
+vcZ
+ycf
 xYB
 xtx
 eLE
@@ -66078,18 +67885,15 @@ aoj
 aoj
 vPg
 vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+bAg
+daA
+eFn
+fAK
+fAK
+fAK
+eFn
+ycf
 vPg
 vPg
 vPg
@@ -66103,8 +67907,11 @@ vPg
 vPg
 vPg
 vPg
-vPg
-eLE
+ycf
+pgc
+xHi
+xHi
+ycf
 eLE
 eLE
 aoj
@@ -66335,36 +68142,36 @@ aoj
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+bNT
+daA
+eFn
+daA
+daA
+daA
+eFn
+ycf
+ycf
+ycf
+ycf
+ycf
+mvA
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+vIC
+vIC
+ycf
+ycf
+ycf
+qYJ
+ycf
+ycf
+ycf
+ycf
 vPg
 vPg
 eLE
@@ -66592,36 +68399,36 @@ dXE
 vPg
 vPg
 vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+bAg
+daA
+daA
+fSW
+fAK
+fAK
+daA
+ycf
+mlV
+ugf
+oEB
+ycf
+shB
+udj
+ycf
+oaJ
+laL
+xoZ
+ycf
+oPs
+hAd
+hMX
+ycf
+vDw
+xEd
+paJ
+fSX
+xHP
+ycf
 vPg
 vPg
 eLE
@@ -66849,36 +68656,36 @@ dXE
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+beZ
+daA
+daA
+fAK
+fAK
+iUQ
+daA
+lbx
+ugf
+ugf
+oNq
+qtE
+srb
+uiu
+ycf
+fOL
+esS
+tby
+vRf
+drx
+scX
+mGb
+ycf
+usA
+cVa
+nFG
+vFJ
+pnQ
+ycf
 vPg
 vPg
 eLE
@@ -67106,36 +68913,36 @@ dXE
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+mvA
+ycf
+lkf
+mno
+ugf
+oAW
+ycf
+acl
+ycf
+ycf
+mvA
+ycf
+pdO
+ycf
+wBj
+wdD
+tLq
+ycf
+kJj
+cVa
+scX
+scX
+lmp
+ycf
 vPg
 vPg
 eLE
@@ -67362,37 +69169,37 @@ wAd
 dXE
 aoj
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+vIC
+lEC
+bPx
+lEC
+eFF
+lEC
+gey
+lEC
+gey
+ycf
+ugf
+vKj
+iOd
+vKj
+ugf
+vKj
+wWp
+oAW
+ugf
+uiy
+ttc
+qQl
+scX
+bIs
+ycf
+cks
+cVa
+hmv
+scX
+lps
+ycf
 vPg
 vPg
 eLE
@@ -67619,37 +69426,37 @@ wju
 dXE
 aoj
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-aoj
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+vIC
+ahJ
+cSw
+ddk
+eKP
+ddk
+gGZ
+otr
+cSw
+qst
+uiy
+ugf
+uiy
+ugf
+uiy
+ugf
+xzi
+ugf
+uiy
+vyR
+euO
+xwZ
+lDp
+bJW
+ycf
+rFu
+cVa
+nzP
+rNi
+pik
+ycf
 vPg
 vPg
 eLE
@@ -67876,37 +69683,37 @@ fkc
 dXE
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+vIC
+scX
+bRN
+dBl
+eMr
+dBl
+ycf
+mvA
+ycf
+ycf
+jek
+obK
+lnZ
+ycf
+ycf
+ycf
+ycf
+lpc
+tig
+tig
+piH
+ycf
+mvA
+ycf
+ycf
+bVL
+cVa
+gty
+xNN
+pgu
+ycf
 vPg
 vPg
 eLE
@@ -68133,37 +69940,37 @@ cYb
 dXE
 vPg
 vPg
-vPg
-vPg
-aoj
-aoj
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+vIC
+lEC
+gey
+lEC
+gey
+lEC
+ycf
+mvg
+kiO
+lqA
+vIC
+vIC
+rHS
+qyz
+sEc
+uiJ
+lzW
+hOO
+qWX
+uiy
+vKj
+iAz
+xEd
+xEd
+iAz
+cVa
+cVa
+cVa
+cVa
+cVa
+ycf
 vPg
 vPg
 eLE
@@ -68390,37 +70197,37 @@ rjz
 dXE
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+tRc
+jfH
+lCw
+mCm
+opM
+pec
+qQw
+qWX
+urT
+blZ
+vIC
+uAa
+vKj
+uiy
+vIC
+vIC
+vIC
+ycf
+nJG
+cVa
+cVa
+cVa
+cVa
+ycf
 vPg
 vPg
 eLE
@@ -68647,37 +70454,37 @@ fiI
 dXE
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
+ycf
+alv
+bTq
+bTq
+bTq
+fYg
+ycf
+iWI
+kzg
+lQf
+vIC
+xsH
+snF
+qWX
+sUH
+uxZ
+xDt
+vIC
+vKj
+vKj
+vIC
+csu
+vGb
+fGL
+ycf
+cVa
+cVa
+cVa
+cVa
+bAM
+ycf
 vPg
 vPg
 eLE
@@ -68904,37 +70711,37 @@ ujX
 dXE
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+ane
+cbn
+bTq
+bTq
+gaw
+ycf
+rHS
+haO
+vLU
+mrp
+xsH
+vIC
+vIC
+vIC
+vIC
+vIC
+fQt
+oAW
+vKj
+rHS
+wyb
+vGb
+xRK
+ycf
+lpZ
+cVa
+cVa
+cVa
+byF
+ycf
 vPg
 vPg
 eLE
@@ -69161,37 +70968,37 @@ sJm
 dXE
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+axF
+chT
+bTq
+bTq
+gmm
+ycf
+phn
+pgv
+xsH
+pgv
+vIC
+eLo
+uiy
+vKj
+uiy
+vKj
+vKj
+vKj
+vKj
+uXV
+mEY
+vGb
+kEa
+lkf
+ycf
+wcI
+ycf
+ycf
+ycf
+ycf
 vPg
 vPg
 eLE
@@ -69418,36 +71225,36 @@ uSk
 dXE
 vPg
 vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+ycf
+ycf
+dBB
+ycf
+ycf
+huo
+goc
+rXm
+xsH
+xsH
+rHS
+gIl
+vKj
+vKj
+vKj
+qiu
+uiy
+uiy
+uiy
+ohL
+vGb
+vGb
+kEa
+ycf
+hjo
+cVa
+dIW
+ykq
+ycf
 vPg
 vPg
 vPg
@@ -69675,36 +71482,36 @@ wSq
 dXE
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+aBg
+aEo
+aEo
+fcz
+gxY
+ycf
+rpE
+dUy
+joD
+pgv
+oqd
+vKj
+uiy
+fQt
+vIC
+vIC
+vIC
+vIC
+vIC
+vIC
+wFF
+gQi
+kEa
+ycf
+iAM
+mrH
+cVa
+vWF
+ycf
 vPg
 vPg
 vPg
@@ -69932,36 +71739,36 @@ wSq
 dXE
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+aEo
+cuJ
+dJh
+fcz
+aEo
+ycf
+hCy
+plc
+cwH
+mth
+vIC
+oAW
+vKj
+vIC
+uCO
+ddL
+jIC
+nKQ
+sVM
+dwM
+vIC
+rHS
+vIC
+ycf
+bMC
+mrH
+cVa
+kmH
+ycf
 vPg
 vPg
 vPg
@@ -70189,36 +71996,36 @@ dXE
 dXE
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
+ycf
+aEo
+cEq
+dXH
+frU
+aEo
+ycf
+vIC
+vIC
+vIC
+vIC
+vKj
+vKj
+rDJ
+tlE
+uGQ
+ddL
+nwp
+ddL
+xGm
+xGm
+xHi
+ykJ
+uXZ
+ycf
+kHo
+cVa
+cVa
+cVa
+ycf
 vPg
 vPg
 vPg
@@ -70446,36 +72253,36 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-aoj
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+aEo
+cLc
+cuJ
+frU
+aEo
+aEo
+mgX
+qwT
+oQt
+muV
+vKj
+vKj
+vKj
+vIC
+uOr
+ddL
+liY
+cPY
+xGm
+xNi
+ubj
+ykJ
+aMF
+ycf
+ycf
+ycf
+dih
+ycf
+ycf
 vPg
 vPg
 vPg
@@ -70703,35 +72510,35 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+aEo
+aEo
+efS
+frU
+aEo
+hvx
+dPd
+tOC
+uDu
+vKj
+vKj
+uiy
+vKj
+tBx
+xGm
+xGm
+sIJ
+xGm
+sIJ
+xNi
+gwZ
+xHi
+xcR
+ycf
+lwj
+oJE
+kAp
+ycf
 vPg
 vPg
 vPg
@@ -70960,35 +72767,35 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+aEo
+cWf
+exD
+fcz
+aEo
+ycf
+vIC
+vIC
+vIC
+nfz
+vKj
+vKj
+vKj
+vIC
+dHh
+xNi
+xNi
+xNi
+xGm
+xNi
+lms
+cOT
+kPj
+ycf
+hOn
+jzW
+oJE
+ycf
 vPg
 vPg
 vPg
@@ -71217,35 +73024,35 @@ vPg
 vPg
 vPg
 vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+aBg
+aEo
+aEo
+fcz
+gxY
+ycf
+wUJ
+sZq
+sZq
+vIC
+gIl
+vKj
+vKj
+tGx
+vIC
+xLc
+kNa
+jxO
+xGm
+aBI
+nzP
+nzP
+cDx
+ycf
+nkg
+jzW
+sgJ
+ycf
 vPg
 vPg
 vPg
@@ -71474,35 +73281,35 @@ aoj
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+wUJ
+sZq
+sZq
+vIC
+oqJ
+vKj
+vKj
+fQt
+vIC
+xZI
+tna
+tOE
+pAk
+cDx
+pjs
+tLK
+bvF
+ycf
+uDX
+oJE
+miu
+ycf
 aoj
 vPg
 vPg
@@ -71734,32 +73541,32 @@ vPg
 vPg
 vPg
 vPg
-aoj
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+jxZ
+kzG
+lZY
+pLH
+vKj
+vKj
+vKj
+vKj
+vIC
+vEI
+cLF
+bJv
+tna
+dlL
+qsI
+xPO
+bbH
+ycf
+ycf
+hGR
+ycf
+ycf
 vPg
 vPg
 vPg
@@ -71993,27 +73800,27 @@ vPg
 vPg
 vPg
 vPg
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+pmR
+saS
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+arc
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
 vPg
 vPg
 vPg
@@ -72250,24 +74057,24 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
+ycf
+hwD
+jyB
+kPQ
+mgD
+nFh
+ycf
+psv
+psv
+ycf
+rFU
+rNz
+efL
+vbU
+rFU
+rNz
+iFS
+ycf
 vPg
 vPg
 vPg
@@ -72507,25 +74314,25 @@ vPg
 vPg
 vPg
 vPg
+ycf
+ihM
+otr
+otr
+otr
+scX
+ycf
+psv
+psv
+ycf
+kAp
+kAp
+oka
+vbU
+oJE
+oJE
+oka
+ycf
 vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
 vPg
 vPg
 vPg
@@ -72764,27 +74571,27 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+ijv
+otr
+kQv
+dBl
+nGf
+ycf
+psv
+psv
+ycf
+uSO
+kAp
+kAp
+vbU
+uSO
+kAp
+kAp
+ycf
+ycf
+ycf
+ycf
 vPg
 vPg
 vPg
@@ -73021,27 +74828,27 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+ikY
+otr
+kVA
+dBl
+nGx
+ycf
+pKX
+pKX
+ycf
+vbi
+vbi
+dAs
+vbU
+vbU
+vbU
+dAs
+ycf
+fEX
+luY
+ycf
 vPg
 vPg
 vPg
@@ -73278,28 +75085,28 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+iwr
+khf
+kXI
+otr
+nQc
+ycf
+pTM
+sdV
+tPg
+vtR
+vtR
+dwj
+dwj
+dwj
+dwj
+dwj
+ycf
+dLq
+cSW
+ycf
 aoj
-vPg
-aoj
-vPg
-vPg
-vPg
 vPg
 vPg
 vPg
@@ -73535,28 +75342,28 @@ tMD
 vPg
 vPg
 vPg
-vPg
-hkD
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+ycf
+ycf
+scX
+scX
+otr
+oAo
+pTM
+sdV
+tPg
+vzF
+wuj
+pTM
+psv
+psv
+psv
+dwj
+qxW
+rKg
+xVE
+ycf
+aoj
 vPg
 vPg
 vPg
@@ -73794,29 +75601,29 @@ tMD
 tMD
 tMD
 tMD
-tMD
-tMD
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+tPC
+wuj
+tho
+pTM
+psv
+psv
+psv
+dwj
+ycf
+rwA
+rKg
+ycf
 aoj
 vPg
 vPg
-vPg
 aoj
-vPg
 vPg
 vPg
 vPg
@@ -74051,25 +75858,25 @@ aBb
 aBb
 aBb
 aBb
-aBb
-aBb
+tMD
+tMD
 tMD
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ycf
+tQP
+wxb
+rTb
+xIG
+oke
+xei
+qbA
+fJO
+ycf
+ycf
+ycf
+ycf
 vPg
 vPg
 vPg
@@ -74314,19 +76121,19 @@ aBb
 tMD
 vPg
 vPg
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
+ycf
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -74581,11 +76388,11 @@ vPg
 vPg
 vPg
 vPg
+vPg
+vPg
 aoj
 vPg
 vPg
-vPg
-aoj
 vPg
 vPg
 vPg
@@ -74838,9 +76645,9 @@ vPg
 vPg
 vPg
 vPg
+vPg
+vPg
 aoj
-vPg
-vPg
 vPg
 vPg
 vPg
@@ -75096,7 +76903,7 @@ vPg
 vPg
 vPg
 vPg
-aoj
+vPg
 aoj
 vPg
 vPg
@@ -76123,7 +77930,7 @@ tMD
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -76386,7 +78193,7 @@ vPg
 vPg
 vPg
 vPg
-aoj
+vPg
 vPg
 vPg
 vPg
@@ -77408,7 +79215,7 @@ rLq
 lnr
 lnr
 aBb
-tMD
+hkD
 vPg
 vPg
 aoj
@@ -77665,7 +79472,7 @@ lnr
 vCe
 lnr
 aBb
-tMD
+hkD
 vPg
 vPg
 aoj
@@ -77922,7 +79729,7 @@ ucS
 hJV
 aBb
 tMD
-vPg
+aoj
 vPg
 vPg
 aoj
@@ -87332,14 +89139,6 @@ vPg
 vPg
 vPg
 vPg
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
 vPg
 vPg
 vPg
@@ -87347,7 +89146,15 @@ vPg
 vPg
 vPg
 vPg
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -87587,24 +89394,24 @@ tur
 vPg
 vPg
 vPg
-aoj
-vPg
-aoj
 vPg
 vPg
 vPg
 vPg
-aoj
 vPg
-aoj
 vPg
-muV
-muV
-muV
-muV
-opM
 vPg
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -87841,25 +89648,25 @@ tur
 weW
 weW
 tur
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-pKX
-pKX
-muV
-muV
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -88098,26 +89905,26 @@ tur
 weW
 weW
 tur
-muV
-gxY
-ijv
-kQv
-ijv
-ijv
-muV
-nQc
-bTq
-chT
-tGx
-tGx
-muV
-beZ
-khf
-uSO
-wuj
-udj
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -88355,29 +90162,29 @@ tur
 weW
 weW
 tur
-muV
-qWX
-ijv
-ijv
-dBB
-kzG
-muV
-gGZ
-tGx
-tGx
-tGx
-pmR
-muV
-gmm
-uSO
-uSO
-uSO
-gmm
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
+vPg
+vPg
+vPg
+vPg
 aoj
+vPg
+vPg
+vPg
 eLE
 eSW
 mTA
@@ -88612,26 +90419,26 @@ tur
 weW
 weW
 tur
-muV
-lqA
-ijv
-ijv
-dBB
-ihM
-muV
-nfz
-tGx
-tGx
-tGx
-tGx
-uOr
-eMr
-uSO
-uSO
-uSO
-eMr
-muV
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -88869,25 +90676,25 @@ tur
 weW
 weW
 tur
-muV
-kzG
-ijv
-ijv
-dBB
-kzG
-mrp
-exD
-tGx
-tGx
-tGx
-lCw
-muV
-gaw
-uSO
-uSO
-uSO
-cbn
-muV
+vPg
+vPg
+aoj
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -89126,25 +90933,25 @@ tur
 weW
 uAY
 tur
-muV
-eFn
-ijv
-ijv
-dBB
-tlE
-muV
-tPC
-tGx
-tGx
-tGx
-tGx
-muV
-eMr
-sEc
-uSO
-uSO
-eMr
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -89383,27 +91190,27 @@ weW
 weW
 weW
 tur
-muV
-fSW
-ijv
-ijv
-dBB
-mno
-muV
-gGZ
-tGx
-tGx
-tGx
-pmR
-muV
-aEo
-uSO
-uSO
-uSO
-cbn
-muV
 vPg
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 eLE
@@ -89640,30 +91447,30 @@ tur
 weW
 weW
 tur
-muV
-ijv
-ijv
-ijv
-ijv
-ijv
-muV
-tGx
-tGx
-dBl
-lkf
-ikY
-muV
-muV
-muV
-muV
-daA
-muV
-muV
-muV
-muV
-muV
-muV
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+eLE
 eSW
 nuI
 vPx
@@ -89897,30 +91704,30 @@ tur
 weW
 weW
 tur
-muV
-muV
-cEq
-muV
-muV
-muV
-muV
-eFF
-mlV
-muV
-muV
-muV
-muV
-iWI
-kVA
-bNT
-bNT
-bNT
-uCO
-sdV
-sdV
-sdV
-xZI
-rDJ
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+eLE
 eSW
 bih
 jrI
@@ -90154,30 +91961,30 @@ tur
 weW
 weW
 rty
-oNq
-bNT
-bNT
-bNT
-axF
-kzg
-bNT
-bNT
-bNT
-hvx
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-muV
-qtE
-vzF
-sdV
-oqd
-dXH
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+eLE
 eSW
 xYf
 jrI
@@ -90411,30 +92218,30 @@ mNE
 weW
 weW
 tur
-xzi
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-pTM
-muV
-oqJ
-vzF
-sdV
-uiJ
-nGf
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+eLE
 eSW
 tdJ
 jrI
@@ -90668,30 +92475,30 @@ mNE
 weW
 weW
 tur
-muV
-oEB
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-bNT
-oAo
-muV
-uiu
-vzF
-wWp
-fAB
-sUH
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+eLE
 eSW
 jrI
 jrI
@@ -90925,30 +92732,30 @@ vfj
 weW
 weW
 tur
-muV
-bNT
-bNT
-bNT
-ddk
-bNT
-bNT
-ddk
-bNT
-bNT
-oAo
-fcz
-bNT
-bNT
-bNT
-ddk
-bNT
-oAo
-muV
-muV
-muV
-muV
-muV
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+eLE
 eSW
 jrI
 laS
@@ -91182,30 +92989,30 @@ tur
 weW
 weW
 tur
-muV
-muV
-muV
-eFF
-muV
-muV
-muV
-tBx
-daA
-muV
-muV
-muV
-muV
-daA
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+eLE
 eSW
 eWC
 tdJ
@@ -91439,30 +93246,30 @@ tur
 weW
 uAY
 tur
-muV
-vbi
-tGx
-tGx
-aBg
-muV
-urT
-fYg
-fYg
-xDt
-fYg
-srb
-muV
-saS
-tQP
-nFh
-lZY
-qyz
-muV
-efS
-tQP
-saS
-wxb
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+eLE
 eSW
 xYf
 tdJ
@@ -91696,30 +93503,30 @@ tur
 weW
 weW
 tur
-muV
-bPx
-tGx
-tGx
-hwD
-muV
-uGQ
-fYg
-fYg
-jyB
-fYg
-huo
-lbx
-saS
-saS
-saS
-saS
-saS
-iPU
-saS
-saS
-mgD
-saS
-muV
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+eLE
 eSW
 eSW
 eSW
@@ -91953,30 +93760,30 @@ tur
 weW
 weW
 tur
-muV
-nGx
-tGx
-tGx
-ahJ
-muV
-cWf
-fYg
-fYg
-xDt
-xDt
-xDt
-muV
-uxZ
-saS
-bAg
-saS
-iwr
-muV
-eKP
-saS
-saS
-saS
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+eLE
 eLE
 eLE
 eLE
@@ -92210,30 +94017,30 @@ tur
 weW
 weW
 tur
-muV
-gGZ
-tGx
-tGx
-iUQ
-muV
-psv
-fYg
-fYg
-jyB
-fYg
-srb
-muV
-vtR
-saS
-frU
-saS
-xLc
-muV
-shB
-saS
-saS
-lQf
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -92467,30 +94274,30 @@ tur
 weW
 weW
 tur
-muV
-cLc
-alv
-fAK
-mth
-muV
-pec
-tPg
-pec
-xDt
-fYg
-huo
-jxZ
-kXI
-saS
-qQw
-saS
-kPQ
-muV
-dJh
-saS
-saS
-cuJ
-muV
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -92724,30 +94531,30 @@ tur
 weW
 weW
 tur
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-muV
-bRN
-muV
-muV
+vPg
+vPg
+aoj
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -92983,9 +94790,6 @@ weW
 tur
 vPg
 vPg
-aoj
-aoj
-aoj
 vPg
 vPg
 vPg
@@ -92993,9 +94797,12 @@ vPg
 vPg
 vPg
 vPg
-aoj
-aoj
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -93241,23 +95048,23 @@ tur
 vPg
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
-aoj
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
 vPg
 vPg
 vPg
@@ -93510,7 +95317,7 @@ vPg
 vPg
 vPg
 vPg
-aoj
+vPg
 vPg
 vPg
 vPg
@@ -93759,8 +95566,7 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 aoj
 vPg
@@ -93768,7 +95574,7 @@ vPg
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 aoj
 vPg
@@ -93776,6 +95582,7 @@ vPg
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
 aoj
@@ -94014,15 +95821,15 @@ xVz
 xVz
 xVz
 vPg
-aoj
-aoj
 vPg
 vPg
 vPg
 vPg
 vPg
 vPg
-aoj
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -94271,12 +96078,6 @@ xVz
 xVz
 xVz
 vPg
-aoj
-aoj
-vPg
-vPg
-aoj
-aoj
 vPg
 vPg
 vPg
@@ -94289,7 +96090,13 @@ vPg
 vPg
 vPg
 vPg
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -94538,7 +96345,7 @@ vPg
 vPg
 vPg
 vPg
-aoj
+vPg
 vPg
 vPg
 vPg

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -23660,15 +23660,6 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/dark,
 /area/f13/underground/enclave_base)
-"oAw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/nest/raider/ranged{
-	pixel_x = -30;
-	spawn_time = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/enclave_base)
 "oAW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -71745,7 +71736,7 @@ uCO
 ddL
 uQb
 qpg
-oAw
+sIJ
 dwM
 vIC
 rHS


### PR DESCRIPTION
A relocation of the Enclave base with a better design and some armory buffs

add: armory buffs (a single set of APA power armor, a few sets of swat armor, and some nonlethal items such as batons, flashbangs, handcuffs, etc)
add: Adds in a new Enclave base
del: Removes the old Enclave base
del:  Removes the old vault dungeon that was never in use

![0SB9H9X](https://user-images.githubusercontent.com/94082600/158002391-ad755c9c-101e-4840-95de-d33fe696ef05.png)

