### PR TITLE
Stops the ugly dark armor from spawning in armor spawners

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -328,7 +328,6 @@
 				/obj/effect/spawner/bundle/f13/armor/swat,
 				/obj/effect/spawner/bundle/f13/armor/combat,
 				/obj/effect/spawner/bundle/f13/armor/bulletproof,
-				/obj/effect/spawner/bundle/f13/armor/combat/dark,
 				/obj/effect/spawner/bundle/f13/armor/sulphite,
 				/obj/effect/spawner/bundle/f13/armor/vault,
 				)


### PR DESCRIPTION
## About The Pull Request

This pull request removes the line of code that makes 'dark combat armor' a version of combat armor which has been given a black spraycan paintjob via-code, so it no longer spawns in armor spawners.

TL;DR:

Removes one line of code

BEFORE:
![image](https://user-images.githubusercontent.com/84290420/159163666-41521d11-7699-4fad-9295-a544c1ac7ed3.png)

AFTER:
![image](https://user-images.githubusercontent.com/84290420/159163684-3cbd27e7-d8ae-43dc-ad0a-7a70177d3084.png)

## Why It's Good For The Game

Whenever I see the dark armor I feel like using my magical powers to learn the name and location of who coded this stupid, ugly, armor in, so I can turn their house and every in it to ash, this pull request hopefully will stop me from doing that.

Also if you don't like this armor it won't spawn anymore, that's also good.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog
:cl:
del: one line of code
/:cl:
